### PR TITLE
Add TLE data source to get-tle-data results

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ copyright = "2024, IAU Centre for the Protection of Dark and Quiet Sky from \
 author = "IAU CPS"
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.0-beta"
+release = "1.0.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -114,7 +114,9 @@ Retrieve raw TLE data for a satellite over a given time period
 
     Get the raw TLE data for a satellite over a given time period - the satellite can be
     identified by either name or NORAD ID. The time period is optional; if not provided,
-    all TLE data available will be returned.
+    all TLE data available will be returned. The data source is also provided, since occasionally
+    satellites with a given NORAD ID can have different preliminary names after launch. This will
+    also help distinguish between similar or identical TLEs with different ``date_collected`` values.
 
    :query id: (*required*) -- identifier of satellite (name or NORAD ID)
    :query id_type: (*required*) -- type of identifier: valid values are "name" or "catalog"
@@ -158,6 +160,7 @@ Retrieve raw TLE data for a satellite over a given time period
 
     [
         {
+            "data_source": "celestrak",
             "date_collected": "2024-04-26 00:35:57 UTC",
             "epoch": "2024-04-25 18:22:37 UTC",
             "satellite_id": 25544,

--- a/src/api/entrypoints/v1/routes/__init__.py
+++ b/src/api/entrypoints/v1/routes/__init__.py
@@ -4,4 +4,4 @@ api_v1 = Blueprint("api_v1", __name__)
 api_main = Blueprint("api_main", __name__)
 
 api_source = "IAU CPS SatChecker"
-api_version = "1.0"
+api_version = "1.0.1"

--- a/src/api/entrypoints/v1/routes/tools_routes.py
+++ b/src/api/entrypoints/v1/routes/tools_routes.py
@@ -116,7 +116,7 @@ def get_tles():
     Returns:
         A JSON response containing the TLE data for the specified satellite
         and date range. Each TLE data entry includes the satellite name,
-        satellite ID, TLE lines, epoch, and date collected.
+        satellite ID, TLE lines, epoch, date collected, and data source.
 
     Raises:
         400:

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -36,7 +36,7 @@ def get_tle_data(
         List[dict]:
             A list containing the TLE data for the specified
             satellite and date range. Each data point includes the satellite
-            name, satellite ID, TLE lines, epoch, and date collected.
+            name, satellite ID, TLE lines, epoch, date collected, and data source.
     """
 
     tles = (
@@ -54,6 +54,7 @@ def get_tle_data(
             "tle_line2": tle.tle_line2,
             "epoch": tle.epoch.strftime("%Y-%m-%d %H:%M:%S %Z"),
             "date_collected": tle.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z"),
+            "data_source": tle.data_source,
         }
         for tle in tles
     ]

--- a/tests/unit/test_tools_service.py
+++ b/tests/unit/test_tools_service.py
@@ -45,6 +45,8 @@ def test_get_tle_data():
         tle_2.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z") in result.values()
         for result in results
     )
+    assert any(tle_1.data_source in result.values() for result in results)
+    assert any(tle_2.data_source in result.values() for result in results)
 
     results = get_tle_data(tle_repo, "not_found", "name", None, None, "test", "1.0")
     assert len(results) == 0


### PR DESCRIPTION
### Description:
Updated JSON results for the tools/get-tle-data endpoint to include the data_source for each TLE

### Context:
Right now you can’t tell the difference between which TLEs came from Celestrak and which ones came from Space-Track - this is an issue because satellites can have different names in each source, so the TLE history can look confusing if the names switch back and forth (MESAT1 and OBJECT G for example.)

Jira issue: [SCK-74](https://noirlab.atlassian.net/browse/SCK-74)

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
