### PR TITLE
Fix for whether satellite is illuminated or not (and tests)

### DIFF
--- a/src/api/utils/coordinate_systems.py
+++ b/src/api/utils/coordinate_systems.py
@@ -399,17 +399,17 @@ def is_illuminated(sat_gcrs: np.array, julian_date: float) -> bool:
     earthsun_norm = earthsun / np.linalg.norm(earthsun)
 
     # Is the satellite in Earth's Shadow?
-    r_parallel = np.dot(sat_gcrs, earthsun_norm) * earthsun_norm
+    r_parallel_length = np.dot(sat_gcrs, earthsun_norm)
+    r_parallel = r_parallel_length * earthsun_norm
     r_tangential = sat_gcrs - r_parallel
+
     illuminated = True
 
-    if np.linalg.norm(r_parallel) < 0:
-        # rearthkm
-        if np.linalg.norm(r_tangential) < 6370:
-            # print(np.linalg.norm(r_tangential),np.linalg.norm(r))
-            # yes the satellite is in Earth's shadow, no need to continue
-            # (except for the moon of course)
-            illuminated = False
+    if np.linalg.norm(r_tangential) < 6370:
+        illuminated = False
+
+        if r_parallel_length > 0:
+            illuminated = True
 
     return illuminated
 
@@ -460,6 +460,8 @@ def get_earth_sun_positions(t: float | Time) -> tuple[np.ndarray, np.ndarray]:
     earth, sun = load_earth_sun()
     earthp = earth.at(time).position.km
     sunp = sun.at(time).position.km
+    print("earthp: ", earthp)
+    print("sunp: ", sunp)
     return earthp, sunp
 
 

--- a/src/api/utils/coordinate_systems.py
+++ b/src/api/utils/coordinate_systems.py
@@ -460,8 +460,6 @@ def get_earth_sun_positions(t: float | Time) -> tuple[np.ndarray, np.ndarray]:
     earth, sun = load_earth_sun()
     earthp = earth.at(time).position.km
     sunp = sun.at(time).position.km
-    print("earthp: ", earthp)
-    print("sunp: ", sunp)
     return earthp, sunp
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -516,7 +516,7 @@ def test_is_illuminated():
     # Examples from SatChecker and checked with Privateer's GlintEvader
     # https://satchecker.cps.iau.org/ephemeris/name/?name=STARLINK-2617&elevation=100
     # &latitude=33&longitude=-110&julian_date=2460546.599502
-    # STARLINK-1477, STARLINK-3154, STARLINK-2617
+    # STARLINK-1477, STARLINK-3154, STARLINK-2617, STARLINK-1986
     # STARLINK-2291, STARLINK-30263, STARLINK-31166
 
     # should be illuminated
@@ -533,6 +533,10 @@ def test_is_illuminated():
     is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
     assert is_illuminated
 
+    sat_gcrs = np.array([-6285.693766146678, -2883.510160329265, 372.90511732453666])
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert is_illuminated
+
     # should not be illuminated
     sat_gcrs = np.array([2148.476260974862, -5720.341032518884, 3250.5047622565057])
     is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
@@ -545,11 +549,6 @@ def test_is_illuminated():
     sat_gcrs = np.array([-145.69690994172956, -6807.470474898967, 877.3659084400132])
     is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
     assert not is_illuminated
-
-    # sunlight side, not illuminated? STARLINK-1986
-    # sat_gcrs = np.array([-6285.693766146678,-2883.510160329265,372.90511732453666])
-    # is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
-    # assert not is_illuminated
 
     # with error
     sat_gcrs = np.array([1.0, 0.0])

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -510,3 +510,48 @@ def test_az_el_to_ra_dec():
     az = None
     with pytest.raises(TypeError):
         ra, dec = coordinate_systems.az_el_to_ra_dec(az, el, lat, lon, jd)
+
+
+def test_is_illuminated():
+    # Examples from SatChecker and checked with Privateer's GlintEvader
+    # https://satchecker.cps.iau.org/ephemeris/name/?name=STARLINK-2617&elevation=100
+    # &latitude=33&longitude=-110&julian_date=2460546.599502
+    # STARLINK-1477, STARLINK-3154, STARLINK-2617
+    # STARLINK-2291, STARLINK-30263, STARLINK-31166
+
+    # should be illuminated
+    sat_gcrs = np.array([-1807.4145165806299, -5481.865083864486, 3817.782079208943])
+    julian_date = 2460546.599502
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert is_illuminated
+
+    sat_gcrs = np.array([-1726.6525239983253, -5556.764988629915, 3732.6312069408664])
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert is_illuminated
+
+    sat_gcrs = np.array([-2788.9344500353254, -6082.063324305135, 1780.452113395069])
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert is_illuminated
+
+    # should not be illuminated
+    sat_gcrs = np.array([2148.476260974862, -5720.341032518884, 3250.5047622565057])
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert not is_illuminated
+
+    sat_gcrs = np.array([1239.1815032279183, -6748.906100431373, 1012.4062279591224])
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert not is_illuminated
+
+    sat_gcrs = np.array([-145.69690994172956, -6807.470474898967, 877.3659084400132])
+    is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    assert not is_illuminated
+
+    # sunlight side, not illuminated? STARLINK-1986
+    # sat_gcrs = np.array([-6285.693766146678,-2883.510160329265,372.90511732453666])
+    # is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
+    # assert not is_illuminated
+
+    # with error
+    sat_gcrs = np.array([1.0, 0.0])
+    with pytest.raises(ValueError):
+        is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)


### PR DESCRIPTION
### Description:
The check for whether a satellite was illuminated was always returning true - fixed the logic and added some tests using GlintEvader from Privateer to confirm satellite location/illumination at particular date/time/location.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
