### PR TITLE
Add endpoint to retrieve the most recent TLE for each satellite with an active sat number/NORAD id (not in docs for now)

### DIFF
--- a/src/api/entrypoints/v1/routes/tools_routes.py
+++ b/src/api/entrypoints/v1/routes/tools_routes.py
@@ -7,6 +7,7 @@ from api.entrypoints.extensions import db, get_forwarded_address, limiter
 from api.services.tools_service import (
     get_ids_for_satellite_name,
     get_names_for_satellite_id,
+    get_recent_tle_set,
     get_tle_data,
 )
 from api.services.validation_service import validate_parameters
@@ -138,6 +139,25 @@ def get_tles():
         parameters["id_type"],
         parameters["start_date_jd"],
         parameters["end_date_jd"],
+        api_source,
+        api_version,
+    )
+
+    return jsonify(tle_data)
+
+
+@api_v1.route("/tools/get-recent-tle-set/")
+@api_main.route("/tools/get-recent-tle-set/")
+@limiter.limit(
+    "100 per second, 2000 per minute", key_func=lambda: get_forwarded_address(request)
+)
+def get_most_recent_tle_set():
+
+    session = db.session
+    tle_repo = SqlAlchemyTLERepository(session)
+
+    tle_data = get_recent_tle_set(
+        tle_repo,
         api_source,
         api_version,
     )

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -61,6 +61,36 @@ def get_tle_data(
     return tle_data
 
 
+def get_recent_tle_set(
+    tle_repo: AbstractTLERepository, api_source: str, api_version: str
+):
+    tles = tle_repo.get_most_recent_full_tle_set()
+
+    # Extract the TLE data from the result set
+    tle_data = [
+        {
+            "satellite_name": tle.satellite.sat_name,
+            "satellite_id": tle.satellite.sat_number,
+            "tle_line1": tle.tle_line1,
+            "tle_line2": tle.tle_line2,
+            "epoch": tle.epoch.strftime("%Y-%m-%d %H:%M:%S %Z"),
+            "date_collected": tle.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z"),
+            "data_source": tle.data_source,
+        }
+        for tle in tles
+    ]
+
+    json_results = [
+        {
+            "count": len(tles),
+            "data": tle_data,
+            "source": api_source,
+            "version": api_version,
+        }
+    ]
+    return json_results
+
+
 def get_ids_for_satellite_name(
     sat_repo: AbstractSatelliteRepository,
     satellite_name: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,9 @@ class FakeTLERepository(AbstractTLERepository):
             default=None,
         )
 
+    def _get_most_recent_full_tle_set(self):
+        return self._tles
+
 
 class FakeSession:
     committed = False


### PR DESCRIPTION
### Description:
Add an endpoint to the tools section to get the most recent TLE for any satellite with has_current_sat_number set to true

### Context:
We need access for collaborators to use TLE data and full database access is an unknown for now, so this should hopefully cover the majority of cases. In future we might protect this endpoint with an API key

