### PR TITLE
Add endpoint to get satellite metadata; update tests and documentation

### DIFF
--- a/docs/source/api_response.rst
+++ b/docs/source/api_response.rst
@@ -140,5 +140,5 @@ Example Response
             "international_designator"
         ],
     "source": "IAU CPS SatChecker",
-    "version": "1.0.2"
+    "version": "1.0.3"
     }

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -3,6 +3,14 @@ Release History
 
 See the full changelog `here <https://github.com/iausathub/satchecker/releases>`_.
 
+v1.0.3
+------------
+* Add endpoint to get satellite data by name or NORAD ID
+
+v1.0.2
+------------
+* Add international designator/COSPAR ID to ephemeris data responses
+
 v1.0.0-beta
 ------------
 * Add versioning to API URL (v1 currently); version is optional and not including it will return the most recent version

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -169,3 +169,62 @@ Retrieve raw TLE data for a satellite over a given time period
             "tle_line2": "2 25544  51.6396 215.3361 0004566  95.7745   7.6568 15.50926567450413"
         }
     ]
+
+
+Retrieve satellite metadata
+---------------------------------------------------------------
+
+.. http:get:: /get-satellite-data/
+   :noindex:
+
+    Get the metadata that SatChecker currently has for a given satellite. This includes the
+    satellite's name, NORAD ID, international designator, launch date, decay date, and
+    any other relevant information.
+
+   :query id: (*required*) -- identifier of satellite (name or NORAD ID)
+   :query id_type: (*required*) -- type of identifier: valid values are "name" or "catalog"
+
+
+**Example Request**
+    .. tabs::
+
+        .. tab:: Browser
+
+            https://satchecker.cps.iau.org/tools/get-satellite-data/?id=25544&id_type=catalog
+
+        .. code-tab:: Python
+
+            import requests
+            import json
+
+            url = 'https://satchecker.cps.iau.org/tools/get-satellite-data/'
+            params = {'id': '25544',
+                      'id_type': 'catalog'
+                    }
+
+            r = requests.get(url, params=params)
+            print(json.dumps(r.json(), indent=4))
+
+        .. code-tab:: Bash
+
+            curl -X GET "https://satchecker.cps.iau.org/tools/get-satellite-data/?id=25544&id_type=catalog" -H "accept: application/json"
+
+        .. code-tab:: Powershell
+
+            curl.exe -X GET "https://satchecker.cps.iau.org/tools/get-satellite-data/?id=25544&id_type=catalog" -H "accept: application/json"
+
+**Example Response**
+
+.. sourcecode:: json
+
+    [
+        {
+            "decay_date": null,
+            "international_designator": "1998-067A",
+            "launch_date": "1998-11-20",
+            "object_type": "PAYLOAD",
+            "rcs_size": "LARGE",
+            "satellite_id": 25544,
+            "satellite_name": "ISS (ZARYA)"
+        }
+    ]

--- a/src/api/adapters/repositories/satellite_repository.py
+++ b/src/api/adapters/repositories/satellite_repository.py
@@ -24,6 +24,12 @@ class AbstractSatelliteRepository(abc.ABC):
     def get_satellite_names_from_norad_id(self, id):
         return self._get_satellite_names_from_norad_id(id)
 
+    def get_satellite_data_by_id(self, id):
+        return self._get_satellite_data_by_id(id)
+
+    def get_satellite_data_by_name(self, name):
+        return self._get_satellite_data_by_name(name)
+
     @abc.abstractmethod
     def _get(self, satellite_id: str) -> Satellite:
         raise NotImplementedError
@@ -34,6 +40,14 @@ class AbstractSatelliteRepository(abc.ABC):
 
     @abc.abstractmethod
     def _get_satellite_names_from_norad_id(self, id):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _get_satellite_data_by_id(self, id):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _get_satellite_data_by_name(self, name):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -106,6 +120,55 @@ class SqlAlchemySatelliteRepository(AbstractSatelliteRepository):
         )
 
         return satellite_names_and_dates
+
+    def _get_satellite_data_by_id(self, id):
+        """
+        Retrieves satellite data (rcs_size, launch date, etc. ) for a given NORAD ID.
+
+        This method queries the database to find a satellite with the specified
+        NORAD ID that also has the current satellite number.
+
+        Args:
+            id (int): The NORAD ID of the satellite.
+
+        Returns:
+            SatelliteDb: The satellite data if found, otherwise None.
+        """
+        satellite = (
+            self.session.query(SatelliteDb)
+            .filter(
+                SatelliteDb.sat_number == id
+                and SatelliteDb.has_current_sat_number == True  # noqa: E712
+            )
+            .first()
+        )
+
+        return satellite
+
+    def _get_satellite_data_by_name(self, name):
+        """
+        Retrieves satellite data (rcs_size, launch date, etc. ) for a given satellite
+        name.
+
+        This method queries the database to find a satellite with the specified
+        name that also has the current satellite number.
+
+        Args:
+            name (str): The name of the satellite.
+
+        Returns:
+            SatelliteDb: The satellite data if found, otherwise None.
+        """
+        satellite = (
+            self.session.query(SatelliteDb)
+            .filter(
+                SatelliteDb.sat_name == name
+                and SatelliteDb.has_current_sat_number == True  # noqa: E712
+            )
+            .first()
+        )
+
+        return satellite
 
     def _add(self, satellite: Satellite):
         orm_satellite = self._to_orm(satellite)

--- a/src/api/entrypoints/v1/routes/tools_routes.py
+++ b/src/api/entrypoints/v1/routes/tools_routes.py
@@ -8,6 +8,7 @@ from api.services.tools_service import (
     get_ids_for_satellite_name,
     get_names_for_satellite_id,
     get_recent_tle_set,
+    get_satellite_data,
     get_tle_data,
 )
 from api.services.validation_service import validate_parameters
@@ -144,6 +145,30 @@ def get_tles():
     )
 
     return jsonify(tle_data)
+
+
+@api_v1.route("/tools/get-satellite-data/")
+@api_main.route("/tools/get-satellite-data/")
+@limiter.limit(
+    "100 per second, 2000 per minute", key_func=lambda: get_forwarded_address(request)
+)
+def get_satellite_data_list():
+    session = db.session
+    sat_repo = SqlAlchemySatelliteRepository(session)
+
+    parameter_list = ["id", "id_type"]
+    required_parameters = ["id", "id_type"]
+    parameters = validate_parameters(request, parameter_list, required_parameters)
+
+    satellite_data = get_satellite_data(
+        sat_repo,
+        parameters["id"],
+        parameters["id_type"],
+        api_source,
+        api_version,
+    )
+
+    return jsonify(satellite_data)
 
 
 @api_v1.route("/tools/get-recent-tle-set/")

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -61,6 +61,45 @@ def get_tle_data(
     return tle_data
 
 
+def get_satellite_data(
+    sat_repo: AbstractSatelliteRepository,
+    id: str,
+    id_type: str,
+    api_source: str,
+    api_version: str,
+):
+    satellite = (
+        sat_repo.get_satellite_data_by_id(id)
+        if id_type == "catalog"
+        else sat_repo.get_satellite_data_by_name(id)
+    )
+
+    if satellite is None:
+        return []
+
+    satellite_data = [
+        {
+            "satellite_name": satellite.sat_name,
+            "satellite_id": satellite.sat_number,
+            "international_designator": satellite.object_id,
+            "rcs_size": satellite.rcs_size,
+            "launch_date": (
+                satellite.launch_date.strftime("%Y-%m-%d")
+                if satellite.launch_date
+                else None
+            ),
+            "decay_date": (
+                satellite.decay_date.strftime("%Y-%m-%d")
+                if satellite.decay_date
+                else None
+            ),
+            "object_type": satellite.object_type,
+        }
+    ]
+
+    return satellite_data
+
+
 def get_recent_tle_set(
     tle_repo: AbstractTLERepository, api_source: str, api_version: str
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,24 @@ class FakeSatelliteRepository(AbstractSatelliteRepository):
             if satellite.sat_number == id
         ]
 
+    def _get_satellite_data_by_id(self, id):
+        return [
+            [satellite.sat_name, datetime(2024, 1, 1), satellite.has_current_sat_number]
+            for satellite in self._satellites
+            if satellite.sat_number == id
+        ]
+
+    def _get_satellite_data_by_name(self, name):
+        return [
+            [
+                satellite.sat_number,
+                datetime(2024, 1, 1),
+                satellite.has_current_sat_number,
+            ]
+            for satellite in self._satellites
+            if satellite.sat_name == name
+        ]
+
     def _get(self, satellite_id):
         return next(
             (

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -326,3 +326,47 @@ def test_get_norad_ids_from_satellite_name_no_match(sqlite_session_factory):
     assert results == []
 
     session.close()
+
+
+def test_get_satellite_data_by_id(sqlite_session_factory):
+    session = sqlite_session_factory()
+    satellite = SatelliteFactory()
+    sat_repository = SqlAlchemySatelliteRepository(session)
+    sat_repository.add(satellite)
+    session.commit()
+
+    results = sat_repository.get_satellite_data_by_id(satellite.sat_number)
+    assert results.sat_name == satellite.sat_name
+    session.close()
+
+
+def test_get_satellite_data_by_id_no_match(sqlite_session_factory):
+    session = sqlite_session_factory()
+    sat_repository = SqlAlchemySatelliteRepository(session)
+    session.commit()
+
+    results = sat_repository.get_satellite_data_by_id("12345")
+    assert results is None
+    session.close()
+
+
+def test_get_satellite_data_by_name(sqlite_session_factory):
+    session = sqlite_session_factory()
+    satellite = SatelliteFactory()
+    sat_repository = SqlAlchemySatelliteRepository(session)
+    sat_repository.add(satellite)
+    session.commit()
+
+    results = sat_repository.get_satellite_data_by_name(satellite.sat_name)
+    assert results.sat_number == satellite.sat_number
+    session.close()
+
+
+def test_get_satellite_data_by_name_no_match(sqlite_session_factory):
+    session = sqlite_session_factory()
+    sat_repository = SqlAlchemySatelliteRepository(session)
+    session.commit()
+
+    results = sat_repository.get_satellite_data_by_name("NO_MATCH")
+    assert results is None
+    session.close()

--- a/tests/integration/test_tools_routes.py
+++ b/tests/integration/test_tools_routes.py
@@ -58,3 +58,20 @@ def test_get_norad_ids_from_name_no_match(client):
     response = client.get("/tools/norad-ids-from-name/?name=ISS")
     assert response.status_code == 200
     assert response.json == []
+
+
+def test_get_satellite_data(client):
+    satellite = SatelliteFactory(sat_name="ISS")
+    sat_repo = satellite_repository.SqlAlchemySatelliteRepository(db.session)
+    sat_repo.add(satellite)
+    db.session.commit()
+
+    response = client.get("/tools/get-satellite-data/?id=ISS&id_type=name")
+    assert response.status_code == 200
+    assert response.json[0]["satellite_name"] == "ISS"
+
+
+def test_get_satellite_data_no_match(client):
+    response = client.get("/tools/get-satellite-data/?id=ISS&id_type=name")
+    assert response.status_code == 200
+    assert response.json == []


### PR DESCRIPTION
### Description:
Add new tools endpoint for data only on the satellite.

### Context:
The primary use for this is SCORE's data page about individual satellites, but it's also available for general use and documented.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
