### PR TITLE
Get satellite info by name: use date_added instead of has_current_sat_number

### DIFF
--- a/src/api/adapters/repositories/satellite_repository.py
+++ b/src/api/adapters/repositories/satellite_repository.py
@@ -161,10 +161,8 @@ class SqlAlchemySatelliteRepository(AbstractSatelliteRepository):
         """
         satellite = (
             self.session.query(SatelliteDb)
-            .filter(
-                SatelliteDb.sat_name == name
-                and SatelliteDb.has_current_sat_number == True  # noqa: E712
-            )
+            .filter(SatelliteDb.sat_name == name)
+            .order_by(SatelliteDb.date_added.desc())
             .first()
         )
 


### PR DESCRIPTION
Change retrieval of satellite info when checking by name to use the most recently added one and not use the has_current_sat_number check

