### PR TITLE
Change 'and' condition to filter satellite search for metadata properly

### DIFF
--- a/src/api/adapters/repositories/satellite_repository.py
+++ b/src/api/adapters/repositories/satellite_repository.py
@@ -137,8 +137,8 @@ class SqlAlchemySatelliteRepository(AbstractSatelliteRepository):
         satellite = (
             self.session.query(SatelliteDb)
             .filter(
-                SatelliteDb.sat_number == id
-                and SatelliteDb.has_current_sat_number == True  # noqa: E712
+                SatelliteDb.sat_number == id,
+                SatelliteDb.has_current_sat_number == True,  # noqa: E712
             )
             .first()
         )


### PR DESCRIPTION
### Description:
The get-satellite-data endpoint was returning unexpected results for some queries by NORAD ID, so fixing the 'and' condition inside the get satellite check made it work as expected

- [ ] Tests up to date

