### PR TITLE
Only allow updates from Space-Track to update the has_current_sat_number flag

### DIFF
--- a/src/data/tle_utils.py
+++ b/src/data/tle_utils.py
@@ -79,7 +79,9 @@ def insert_records(
         logging.info(f"{log_time}\tnew satellite: {satellite.model.satnum}")
 
     # make sure this satellite has the correct has_current_sat_number value
-    if is_current_number:
+    # only allow data from space-track to update this value, celestrak has
+    # had a few instances of name changes outside of preliminary names
+    if is_current_number and source == "spacetrack":
         update_query = """
             UPDATE satellites
             SET HAS_CURRENT_SAT_NUMBER = TRUE,


### PR DESCRIPTION
### Description:
Only allow updates from Space-Track to update the has_current_sat_number flag to prevent differences in Celestrak satellite names from being marked as primary

### Context:
Occasionally Celestrak has a different name for a satellite, and that update throws off the has_current_sat_number flag, since we want to stick with Space-Track as the more "official" of the two sources.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
