### PR TITLE
Add endpoint to get all TLEs for a given date

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@
 ### Context:
 
 
+JIRA issue: [SCK-](https://noirlab.atlassian.net/browse/SCK-)
+
 - [ ] Tests up to date
 - [ ] Code documentation up to date
 - [ ] Project documentation up to date

--- a/docs/source/api_response.rst
+++ b/docs/source/api_response.rst
@@ -140,5 +140,5 @@ Example Response
             "international_designator"
         ],
     "source": "IAU CPS SatChecker",
-    "version": "1.0.3"
+    "version": "1.0.4"
     }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ copyright = "2024, IAU Centre for the Protection of Dark and Quiet Sky from \
 author = "IAU CPS"
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.3"
+release = "1.0.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,4 +1,4 @@
-URL Examples
+Examples
 =============
 
 Here are a few examples of how to use the API:
@@ -12,3 +12,54 @@ https://satchecker.cps.iau.org/ephemeris/name-jdstep/?name=STARLINK-1600&latitud
 
 **Attempt to get visible passes STARLINK-1600 at a given location for the specified time range, with no results:**
 https://satchecker.cps.iau.org/ephemeris/name-jdstep/?name=STARLINK-1600&latitude=40.1106&longitude=-88.2073&elevation=222&startjd=2460000.1&stopjd=2460000.3&stepjd=0.1
+
+--------------------------
+
+**Get all TLEs for active objects at the current epoch:**
+
+.. code-block:: python
+
+    from datetime import datetime, timezone
+    import pandas as pd
+    import requests
+
+    def get_tles_at_epoch(base_url, epoch_date=None, page=1, per_page=100):
+        url = f"{base_url}/tools/tles-at-epoch/"
+        params = {
+            "epoch": epoch_date,
+            "page": page,
+            "per_page": per_page
+        }
+        response = requests.get(url, params=params, timeout=10)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            response.raise_for_status()
+
+    def fetch_all_tles(base_url, epoch_date=None, data_source="spacetrack"):
+        all_tles = []
+        page = 1
+        per_page = 100
+
+        while True:
+            results = get_tles_at_epoch(base_url, epoch_date, page, per_page)
+            tles = results[0]["data"]
+            all_tles.extend(tles)
+            if len(tles) < per_page:
+                break
+            page += 1
+
+        return all_tles
+
+    if __name__ == "__main__":
+        base_url = "https://satchecker.cps.iau.org"
+
+        # This will give the current TLE set, use a specific epoch (in Julian date format) if needed
+        # epoch_date = 2460606
+        all_tles = fetch_all_tles(base_url""", epoch_date=epoch_date """)
+
+        # Create a DataFrame from the TLE data
+        df = pd.DataFrame(all_tles)
+        print(df.columns)
+        print(df.head())
+        print(df.shape[0])

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -3,6 +3,10 @@ Release History
 
 See the full changelog `here <https://github.com/iausathub/satchecker/releases>`_.
 
+v1.0.4
+------------
+* Add endpoint to get all TLEs for active objects at the current (or specified ) epoch.
+
 v1.0.3
 ------------
 * Add endpoint to get satellite data by name or NORAD ID

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -237,8 +237,9 @@ This endpoint fetches all TLEs at a specific epoch date. It supports pagination 
 If the epoch date is not provided, it defaults to returning the most recent TLE for every active satellite/object
 in the database (no decay date and current NORAD ID).
 
-For an example on how to use this endpoint to get all TLEs for the current date using Python and a Pandas DataFrame,
-see the example on the :doc:`examples page <examples>`.
+.. note::
+    For an example on how to use this endpoint to get all TLEs for the current date using Python and a Pandas DataFrame,
+    check out the :doc:`examples page <examples>`.
 
 **Endpoint**
 
@@ -327,6 +328,6 @@ see the example on the :doc:`examples page <examples>`.
                 "per_page": 5,
                 "source": "IAU CPS SatChecker",
                 "total_results": 385,
-                "version": "1.0.3"
+                "version": "1.0.4"
             }
         ]

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -228,3 +228,105 @@ Retrieve satellite metadata
             "satellite_name": "ISS (ZARYA)"
         }
     ]
+
+
+Get full TLE set at Epoch
+---------------------------------------------------------------
+
+This endpoint fetches all TLEs at a specific epoch date. It supports pagination to handle large result sets.
+If the epoch date is not provided, it defaults to returning the most recent TLE for every active satellite/object
+in the database (no decay date and current NORAD ID).
+
+For an example on how to use this endpoint to get all TLEs for the current date using Python and a Pandas DataFrame,
+see the example on the :doc:`examples page <examples>`.
+
+**Endpoint**
+
+.. http:get:: /tools/tles-at-epoch/
+
+    **Parameters**
+
+    :query epoch: (*optional*) -- The epoch date for the TLE data, in Julian Date format. Defaults to the current date if not provided.
+    :query page: (*optional*) -- The page number for pagination. Defaults to 1.
+    :query per_page: (*optional*) -- The number of results per page for pagination. Defaults to 100.
+
+    **Example Request**
+
+    .. tabs::
+
+        .. tab:: Browser
+
+            https://satchecker.cps.iau.org/tools/tles-at-epoch/?epoch=2459488.5&page=1&per_page=10
+
+        .. tab:: Bash
+
+            .. code-tab:: Bash
+
+                curl -X GET "https://satchecker.cps.iau.org/tools/tles-at-epoch/?epoch=2459488.5&page=1&per_page=10" -H "accept: application/json"
+
+        .. tab:: Powershell
+
+            .. code-tab:: Powershell
+
+                curl.exe -X GET "https://satchecker.cps.iau.org/tools/tles-at-epoch/?epoch=2459488.5&page=1&per_page=10" -H "accept: application/json"
+
+    **Example Response**
+
+    .. sourcecode:: json
+
+        [
+            {
+                "data": [
+                    {
+                        "data_source": "spacetrack",
+                        "date_collected": "2024-07-17 19:06:09 UTC",
+                        "epoch": "2024-06-18 14:40:11 UTC",
+                        "satellite_id": 26967,
+                        "satellite_name": "DELTA 2 DEB",
+                        "tle_line1": "1 26967U 93017E   24170.61124217  .00016791  00000-0  44967-3 0  9995",
+                        "tle_line2": "2 26967  34.9300 154.9280 3885867 208.4643 123.3999  7.71838818573239"
+                    },
+                    {
+                        "data_source": "spacetrack",
+                        "date_collected": "2024-07-17 19:06:09 UTC",
+                        "epoch": "2024-06-20 16:17:21 UTC",
+                        "satellite_id": 31723,
+                        "satellite_name": "FENGYUN 1C DEB",
+                        "tle_line1": "1 31723U 99025CDW 24172.67871604  .00004507  00000-0  26310-2 0  9996",
+                        "tle_line2": "2 31723  97.8187 334.7099 0122012 256.7917 101.9619 14.05166935558935"
+                    },
+                    {
+                        "data_source": "spacetrack",
+                        "date_collected": "2024-07-17 19:06:14 UTC",
+                        "epoch": "2024-06-29 11:39:33 UTC",
+                        "satellite_id": 270291,
+                        "satellite_name": "TBA - TO BE ASSIGNED",
+                        "tle_line1": "1 T0291U 11061F   24181.48580305  .07957539  53890-5  11314-2 0  9997",
+                        "tle_line2": "2 T0291 101.6670  18.4903 0018493 268.3973  91.5188 16.34237302695039"
+                    },
+                    {
+                        "data_source": "spacetrack",
+                        "date_collected": "2024-07-17 19:06:14 UTC",
+                        "epoch": "2024-07-02 15:04:27 UTC",
+                        "satellite_id": 59979,
+                        "satellite_name": "TITAN 3C TRANSTAGE DEB",
+                        "tle_line1": "1 59979U 68081AM  24184.62809922 -.00000169  00000-0  00000-0 0  9996",
+                        "tle_line2": "2 59979   1.0181  53.6452 0044622 145.5716  26.1521  1.03320921 55136"
+                    },
+                    {
+                        "data_source": "spacetrack",
+                        "date_collected": "2024-07-17 19:06:14 UTC",
+                        "epoch": "2024-07-02 17:27:58 UTC",
+                        "satellite_id": 59982,
+                        "satellite_name": "TITAN 3C TRANSTAGE DEB",
+                        "tle_line1": "1 59982U 68081AQ  24184.72776552 -.00000306  00000-0  00000-0 0  9996",
+                        "tle_line2": "2 59982   1.7568 344.5114 0737782 293.5946  58.6594  0.99574789 12914"
+                    }
+                ],
+                "page": 1,
+                "per_page": 5,
+                "source": "IAU CPS SatChecker",
+                "total_results": 385,
+                "version": "1.0.3"
+            }
+        ]

--- a/setup/CONTRIBUTING.md
+++ b/setup/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Guide to contributing to SatChecker
 
-Welcome to the SatChecker contributing guide! SatChecker is a tool for predicting satellite positions and providing other relevant data, developed by the IAU Centre for the Protection of the Dark and Quiet Sky from Satellite Constellation Interference (IAU CPS) SatHub group. 
+Welcome to the SatChecker contributing guide! SatChecker is a tool for predicting satellite positions and providing other relevant data, developed by the IAU Centre for the Protection of the Dark and Quiet Sky from Satellite Constellation Interference (IAU CPS) SatHub group.
 
 Bug report/fixes, feature requests, and other contributions are welcome, and all issues and pull requests will be reviewed by a repo maintainer to ensure consistency with the project's scope and other guidelines.
 
@@ -20,7 +20,7 @@ For any questions not answered here please email sathub@cps.iau.org or open an i
 
 * Pytest is used for testing.
 
-* Use Google-style docstrings -- example: 
+* Use Google-style docstrings -- example:
 ```
 def add_numbers(a: int, b: int) -> int:
     """Add two numbers together.
@@ -45,4 +45,4 @@ def add_numbers(a: int, b: int) -> int:
 
 
 #### License Info
-All code that is part of SatChecker is currently released under the [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/) license.
+All code that is part of SatChecker is currently released under the [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause) license.

--- a/src/api/adapters/repositories/tle_repository.py
+++ b/src/api/adapters/repositories/tle_repository.py
@@ -59,9 +59,6 @@ class AbstractTLERepository(abc.ABC):
             satellite_name, start_date, end_date
         )
 
-    def get_most_recent_full_tle_set(self):
-        return self._get_most_recent_full_tle_set()
-
     def get_all_tles_at_epoch(
         self, epoch_date: datetime, page: int, per_page: int
     ) -> Tuple[List[TLE], int]:
@@ -95,10 +92,6 @@ class AbstractTLERepository(abc.ABC):
         start_date: Optional[datetime],
         end_date: Optional[datetime],
     ) -> TLE:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_most_recent_full_tle_set(self):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/src/api/adapters/repositories/tle_repository.py
+++ b/src/api/adapters/repositories/tle_repository.py
@@ -240,9 +240,14 @@ class SqlAlchemyTLERepository(AbstractTLERepository):
             )
             .join(TLEDb.satellite)
             .filter(
-                SatelliteDb.has_current_sat_number == True,  # noqa: E712
-                SatelliteDb.decay_date == None,  # noqa: E711
-            )  # noqa: E711
+                or_(
+                    SatelliteDb.decay_date == None,  # Still active  # noqa: E711
+                    SatelliteDb.decay_date > epoch_date,  # Decayed after the epoch date
+                )
+            )
+            # used in place of checking has_current_sat_number to make sure two TLEs
+            # for the same satellite don't get added
+            .distinct(TLEDb.tle_line1)
             .order_by(TLEDb.epoch)
         )
         # get the count of the query pre-pagination

--- a/src/api/common/error_messages.py
+++ b/src/api/common/error_messages.py
@@ -22,3 +22,4 @@ NO_TLE_FOUND = "Error: No TLE found"
 TOO_MANY_RESULTS = (
     "Error: Too many results to return (maximum of 1000 in a single request)"
 )
+PAGINATION_LIMIT_EXCEEDED = "Error: Pagination limit exceeded"

--- a/src/api/entrypoints/v1/routes/__init__.py
+++ b/src/api/entrypoints/v1/routes/__init__.py
@@ -4,4 +4,4 @@ api_v1 = Blueprint("api_v1", __name__)
 api_main = Blueprint("api_main", __name__)
 
 api_source = "IAU CPS SatChecker"
-api_version = "1.0.3"
+api_version = "1.0.4"

--- a/src/api/entrypoints/v1/routes/tools_routes.py
+++ b/src/api/entrypoints/v1/routes/tools_routes.py
@@ -186,7 +186,7 @@ def get_tles_at_epoch():
     arguments. It also supports pagination to handle large result sets.
 
     Parameters:
-        epoch_date (str):
+        epoch (str):
             The epoch date for the TLE data, in Julian Date format.
         page (int, optional):
             The page number for pagination.
@@ -207,10 +207,10 @@ def get_tles_at_epoch():
     session = db.session
     tle_repo = SqlAlchemyTLERepository(session)
 
-    parameter_list = ["epoch_date", "page", "per_page"]
+    parameter_list = ["epoch", "page", "per_page"]
     parameters = validate_parameters(request, parameter_list, [])
 
-    epoch_date = parameters.get("epoch_date")
+    epoch_date = parameters.get("epoch")
     if not epoch_date:
         epoch_date = datetime.now(timezone.utc)
 

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -68,6 +68,25 @@ def get_satellite_data(
     api_source: str,
     api_version: str,
 ):
+    """
+    Fetches satellite data based on the provided ID and ID type.
+
+    This function retrieves satellite metadata from the repository based on the
+    provided ID. The ID can be either a catalog ID or a satellite name, determined
+    by the id_type parameter.
+
+    Parameters:
+        sat_repo (AbstractSatelliteRepository): The repository to fetch satellite data
+        from.
+        id (str): The ID of the satellite, either a catalog ID or a satellite name.
+        id_type (str): The type of the ID, either "catalog" or "name".
+        api_source (str): The source of the API request.
+        api_version (str): The version of the API request.
+
+    Returns:
+        List[Dict[str, Any]]: A list containing a dictionary with satellite data.
+                              Returns an empty list if no satellite data is found.
+    """
     satellite = (
         sat_repo.get_satellite_data_by_id(id)
         if id_type == "catalog"
@@ -100,10 +119,33 @@ def get_satellite_data(
     return satellite_data
 
 
-def get_recent_tle_set(
-    tle_repo: AbstractTLERepository, api_source: str, api_version: str
+def get_all_tles_at_epoch(
+    tle_repo: AbstractTLERepository,
+    epoch_date: datetime,
+    page: int,
+    per_page: int,
+    api_source: str,
+    api_version: str,
 ):
-    tles = tle_repo.get_most_recent_full_tle_set()
+    """
+    Fetches all TLEs at a specific epoch date with pagination support.
+
+    This function retrieves TLE data from the repository based on the provided epoch
+    date.It supports pagination to handle large result sets.
+
+    Parameters:
+        tle_repo (AbstractTLERepository): The repository to fetch TLE data from.
+        epoch_date (datetime): The epoch date for the TLE data.
+        page (int): The page number for pagination.
+        per_page (int): The number of results per page for pagination.
+        api_source (str): The source of the API request.
+        api_version (str): The version of the API request.
+
+    Returns:
+        List[Dict[str, Any]]: A list containing a dictionary with TLE data and
+        pagination info.
+    """
+    tles, total_count = tle_repo.get_all_tles_at_epoch(epoch_date, page, per_page)
 
     # Extract the TLE data from the result set
     tle_data = [
@@ -121,7 +163,9 @@ def get_recent_tle_set(
 
     json_results = [
         {
-            "count": len(tles),
+            "per_page": per_page,
+            "page": page,
+            "total_results": total_count,
             "data": tle_data,
             "source": api_source,
             "version": api_version,

--- a/src/api/services/validation_service.py
+++ b/src/api/services/validation_service.py
@@ -178,6 +178,16 @@ def validate_parameters(
         except Exception as e:
             raise ValidationError(500, error_messages.INVALID_JD, e) from e
 
+    if "epoch" in parameters.keys() and parameters["epoch"] is not None:
+        try:
+            parameters["epoch"] = (
+                Time(parameters["epoch"], format="jd", scale="ut1")
+                .to_datetime()
+                .replace(tzinfo=timezone.utc)
+            )
+        except Exception as e:
+            raise ValidationError(500, error_messages.INVALID_JD, e) from e
+
     return parameters
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,9 +166,6 @@ class FakeTLERepository(AbstractTLERepository):
             default=None,
         )
 
-    def _get_most_recent_full_tle_set(self):
-        return self._tles
-
 
 class FakeSession:
     committed = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,9 @@ class FakeTLERepository(AbstractTLERepository):
             default=None,
         )
 
+    def _get_all_tles_at_epoch(self, epoch_date, page, per_page):
+        return list(self._tles), len(self._tles)
+
 
 class FakeSession:
     committed = False

--- a/tests/integration/test_tools_routes.py
+++ b/tests/integration/test_tools_routes.py
@@ -100,7 +100,9 @@ def test_get_tles_at_epoch_pagination(client):
     db.session.commit()
 
     epoch_date = tle.epoch.strftime("%Y-%m-%d")
-    response = client.get(f"/ephemeris/tles-at-epoch/?epoch_date={epoch_date}&page=1&per_page=1")
+    response = client.get(
+        f"/ephemeris/tles-at-epoch/?epoch_date={epoch_date}&page=1&per_page=1"
+    )
 
     assert response.status_code == 200
     assert len(response.json) == 1


### PR DESCRIPTION
### Description:
Add a new endpoint to get all TLEs for either the current date (default if no epoch is given), or any specified date. The results are paginated due to the large number of TLEs - the number of results per page is also an optional parameter.  The documentation also now has an example of a Python script that can be used to load all TLEs from the API response into a Pandas DataFrame.

### Context:
This provides the ability to get a snapshot of all active satellite TLEs at any given date.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
