### PR TITLE
Add option to get TLE data at an epoch in txt format

### DIFF
--- a/dev/fov_verification.md
+++ b/dev/fov_verification.md
@@ -4,7 +4,7 @@
 This uses position data obtained from SCORE to verify/compare the position data obtained from the FOV API.
 For Pelican 3001, other satellites found in the FOV query are also plotted, but not for ACS 3 since with the longer duration and field of view, there were too many satellites to plot.
 
-The track separation is currently the difference is between points on the observed/predicted tracks. This means that the separation noted might be larger than the actual track separation if there are gaps in the data. Track separation should either calculate the distance between the tracks themselves or the FOV/data set should be split into smaller chunks to avoid gaps.
+The track separation is currently the difference is between points on the observed/predicted tracks. This means that the separation noted might be larger than the actual track separation if there are gaps in the data. The cadence of the observations also affects this - the FOV API returns position on a preset basis (1 second) so if the observations are more/less frequent, the separation between points might be larger. Track separation should either calculate the distance between the tracks themselves or the FOV/data set should be split into smaller chunks to avoid gaps.
 
 ### Pelican 3001 - 8 degree FOV
 <img src="../docs/source/images/pelican_3001_05082024.png" alt="Pelican 3001 - 05-08-2024" width="100%"/>

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -252,7 +252,7 @@ in the database (no decay date and current NORAD ID).
     :query epoch: (*optional*) -- The epoch date for the TLE data, in Julian Date format. Defaults to the current date if not provided.
     :query page: (*optional*) -- The page number for pagination. Defaults to 1.
     :query per_page: (*optional*) -- The number of results per page for pagination. Defaults to 100.
-    :query format: (*optional*) -- The format of the response. Valid values are "json" (default) or "zip". The "zip" option will return a zip file containing a CSV file with the TLE data.
+    :query format: (*optional*) -- The format of the response. Valid values are "json" (default), "txt", or "zip". The "zip" option will return a zip file containing a CSV file with the TLE data.
 
     **Example Request**
 

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -2,6 +2,7 @@ import csv
 import io
 import zipfile
 from datetime import datetime
+from typing import Union
 
 from api.adapters.repositories.satellite_repository import AbstractSatelliteRepository
 from api.adapters.repositories.tle_repository import AbstractTLERepository
@@ -177,114 +178,109 @@ def get_active_satellites(
     }
 
 
-def get_all_tles_at_epoch_paginated(
+def get_all_tles_at_epoch_formatted(
     tle_repo: AbstractTLERepository,
     epoch_date: datetime,
-    page: int,
-    per_page: int,
-    api_source: str,
-    api_version: str,
-):
+    format: str = "json",
+    page: int = 1,
+    per_page: int = 100,
+    api_source: str = "",
+    api_version: str = "",
+) -> Union[list, io.BytesIO]:
     """
-    Fetches all TLEs at a specific epoch date with pagination support.
-
-    This function retrieves TLE data from the repository based on the provided epoch
-    date.It supports pagination to handle large result sets.
+    Fetches all TLEs at a specific epoch date with support for different output formats.
 
     Parameters:
         tle_repo (AbstractTLERepository): The repository to fetch TLE data from.
         epoch_date (datetime): The epoch date for the TLE data.
-        page (int): The page number for pagination.
-        per_page (int): The number of results per page for pagination.
+        format (str): Output format - either "json", "txt", or "zip".
+        page (int): The page number for pagination (used for JSON format).
+        per_page (int): The number of results per page (used for JSON format).
         api_source (str): The source of the API request.
         api_version (str): The version of the API request.
 
     Returns:
-        List[Dict[str, Any]]: A list containing a dictionary with TLE data and
-        pagination info.
+        Union[list, io.BytesIO]: Either a list containing TLE data and pagination info
+                                (JSON) or a BytesIO object containing formatted TLE data
+                                (TXT/ZIP).
     """
+    # For text format, get all records
+    actual_per_page = 1000000 if format == "txt" else per_page
+    actual_page = 1 if format == "txt" else page
+
     tles, total_count = tle_repo.get_all_tles_at_epoch(
-        epoch_date, page, per_page, "json"
+        epoch_date, actual_page, actual_per_page, format
     )
 
-    # Extract the TLE data from the result set
-    tle_data = [
-        {
-            "satellite_name": tle.satellite.sat_name,
-            "satellite_id": tle.satellite.sat_number,
-            "tle_line1": tle.tle_line1,
-            "tle_line2": tle.tle_line2,
-            "epoch": tle.epoch.strftime("%Y-%m-%d %H:%M:%S %Z"),
-            "date_collected": tle.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z"),
-            "data_source": tle.data_source,
-        }
-        for tle in tles
-    ]
-
-    json_results = [
-        {
-            "per_page": per_page,
-            "page": page,
-            "total_results": total_count,
-            "data": tle_data,
-            "source": api_source,
-            "version": api_version,
-        }
-    ]
-    return json_results
-
-
-def get_all_tles_at_epoch_zipped(
-    tle_repo: AbstractTLERepository,
-    epoch_date: datetime,
-    page: int,
-    per_page: int,
-    api_source: str,
-    api_version: str,
-):
-    tles, total_count = tle_repo.get_all_tles_at_epoch(
-        epoch_date, page, per_page, "zip"
-    )
-
-    # Create CSV data in memory
-    csv_buffer = io.StringIO()
-    csv_writer = csv.writer(csv_buffer)
-
-    # Write header
-    csv_writer.writerow(
-        [
-            "satellite_name",
-            "satellite_id",
-            "tle_line1",
-            "tle_line2",
-            "epoch",
-            "date_collected",
-            "data_source",
+    if format == "txt":
+        tle_data = [
+            f"{tle.satellite.sat_name}\n{tle.tle_line1}\n{tle.tle_line2}\n"
+            for tle in tles
         ]
-    )
+        text_content = "".join(tle_data)
+        return io.BytesIO(text_content.encode())
 
-    # Write data
-    for tle in tles:
+    elif format == "zip":
+        csv_buffer = io.StringIO()
+        csv_writer = csv.writer(csv_buffer)
+
         csv_writer.writerow(
             [
-                tle.satellite.sat_name,
-                tle.satellite.sat_number,
-                tle.tle_line1,
-                tle.tle_line2,
-                tle.epoch.strftime("%Y-%m-%d %H:%M:%S %Z"),
-                tle.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z"),
-                tle.data_source,
+                "satellite_name",
+                "satellite_id",
+                "tle_line1",
+                "tle_line2",
+                "epoch",
+                "date_collected",
+                "data_source",
             ]
         )
 
-    # Create zip file in memory
-    zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
-        zip_file.writestr("tle_data.csv", csv_buffer.getvalue())
+        for tle in tles:
+            csv_writer.writerow(
+                [
+                    tle.satellite.sat_name,
+                    tle.satellite.sat_number,
+                    tle.tle_line1,
+                    tle.tle_line2,
+                    tle.epoch.strftime("%Y-%m-%d %H:%M:%S %Z"),
+                    tle.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z"),
+                    tle.data_source,
+                ]
+            )
 
-    zip_buffer.seek(0)
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("tle_data.csv", csv_buffer.getvalue())
 
-    return zip_buffer
+        zip_buffer.seek(0)
+        return zip_buffer
+
+    else:
+        # Format as JSON
+        tle_data = [
+            {
+                "satellite_name": tle.satellite.sat_name,
+                "satellite_id": tle.satellite.sat_number,
+                "tle_line1": tle.tle_line1,
+                "tle_line2": tle.tle_line2,
+                "epoch": tle.epoch.strftime("%Y-%m-%d %H:%M:%S %Z"),
+                "date_collected": tle.date_collected.strftime("%Y-%m-%d %H:%M:%S %Z"),
+                "data_source": tle.data_source,
+            }
+            for tle in tles
+        ]
+
+        return [
+            {
+                "per_page": per_page,
+                "page": page,
+                "total_results": total_count,
+                "data": tle_data,
+                "source": api_source,
+                "version": api_version,
+            }
+        ]
 
 
 def get_ids_for_satellite_name(

--- a/src/api/services/validation_service.py
+++ b/src/api/services/validation_service.py
@@ -236,7 +236,7 @@ def validate_parameters(
     if "format" in parameters.keys() and parameters["format"] is not None:
         parameters["format"] = parameters["format"].lower()
 
-        if parameters["format"] not in ["json", "zip"]:
+        if parameters["format"] not in ["json", "zip", "txt"]:
             raise ValidationError(500, error_messages.INVALID_FORMAT)
 
     if "group_by" in parameters.keys() and parameters["group_by"] is not None:


### PR DESCRIPTION
### Description:
Add option to format parameter in tles-at-epoch to get TLEs in txt format similar to the three line one used by Celestrak and others. The txt file is satellite name, TLE line 1, and TLE line 2. If the additional data on TLE collection is needed, you still have to use the JSON or .zip/.CSV option

### Context:
This format is one that is already used by other code that works with satellite TLEs, so this change increases compatibility and reduces the need to convert to something usable.

JIRA issue: [SCK-108](https://noirlab.atlassian.net/browse/SCK-108)

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
