### PR TITLE
Cache recent TLE set 

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r src/api/requirements.txt
+      - name: Run type checking
+        run: |
+          mypy .
 
 
   test:

--- a/docs/source/fov.rst
+++ b/docs/source/fov.rst
@@ -131,7 +131,7 @@ Satellite passes Through FOV
                                 "altitude": 3.91713221,
                                 "angle": 2.21383004,
                                 "azimuth": 289.12315208,
-                                    "date_time": "2024-11-08 21:28:29 UTC",
+                                "date_time": "2024-11-08 21:28:29 UTC",
                                 "dec": 18.26370601,
                                 "julian_date": 2460623.39479157,
                                 "ra": 156.04618993,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,36 @@ exclude = '''
 lint.select = ["E", "F", "I", "N", "UP", "S", "B"]
 src = ["src"]
 
+[tool.mypy]
+mypy_path = "src"
+
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = true
+disallow_untyped_decorators = false
+no_implicit_optional = true
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+explicit_package_bases = true
+
+exclude = [
+  'api/migrations',
+  'docs',
+  'examples',
+  'tests',
+  'env',
+  'data',
+]
+
+
+[[tool.mypy.overrides]]
+module = ["flask.*", "sqlalchemy.*", "celery.*", "redis.*", "astropy.*", "flasgger.*", "flask_apscheduler.*", 'flask_migrate.*', 'requests.*', 'skyfield.*', 'sgp4.*']
+ignore_missing_imports = true
+
 [tool.towncrier]
 directory = "src/api/changes"
 package_dir = "src"

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,26 +1,31 @@
+"""API package initialization."""
+
 import logging
 import os
+import sys
 
 from flask import Flask
-from flask_migrate import Migrate
 
 from api.celery_app import celery
-from api.config import get_db_login
-from api.entrypoints.extensions import db, limiter, swagger
-from api.entrypoints.v1.routes import api_main, api_v1
-from api.entrypoints.v1.routes import ephemeris_routes as ephem_routes  # noqa: F401
-from api.entrypoints.v1.routes import fov_routes as fov_routes  # noqa: F401, I001
-from api.entrypoints.v1.routes import routes as v1_routes  # noqa: F401, I001
-from api.entrypoints.v1.routes import tools_routes as tool_routes  # noqa: F401, I001
-from api.middleware.error_handler import init_error_handler
 
 
-def create_app():
+def create_app(test_config=None):
+    """Create and configure the Flask application."""
     app = Flask(__name__, static_url_path="/static")
+
+    # Import and register blueprints
+    from api.entrypoints.v1.routes import api_main, api_v1
 
     app.register_blueprint(api_main, url_prefix="/")
     app.register_blueprint(api_v1, url_prefix="/v1")
+
+    # Initialize error handler
+    from api.middleware.error_handler import init_error_handler
+
     init_error_handler(app)
+
+    # Configure database
+    from api.config import get_db_login
 
     db_login = get_db_login()
 
@@ -55,24 +60,71 @@ def create_app():
         "openapi": "3.0.2",
         "specs_route": "/api/docs/",
         "static_url_path": "/static",
-        "template_file": "flasgger/index.html",  # Use our custom template
+        "template_file": "flasgger/index.html",  # Use the custom template
     }
 
-    # Initialize Flask-Migrate
+    # Initialize extensions
+    from api.entrypoints.extensions import db, limiter, swagger
+
+    db.init_app(app)
+    limiter.init_app(app)
+    swagger.init_app(app)
+
+    # Initialize migrations
+    from flask_migrate import Migrate
+
     migrate = Migrate(app, db)  # noqa: F841
-    with app.app_context():
-        return app
+
+    # Initialize celery
+
+    celery.conf.update(app.config)
+    app.extensions["celery"] = celery
+
+    setup_logging(app)
+
+    return app
+
+
+def setup_logging(app):
+    """Set up logging based on the running environment."""
+    # First, clear any existing handlers to avoid duplicates
+    if app.logger.handlers:
+        app.logger.handlers = []
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    is_gunicorn = "gunicorn" in sys.modules
+
+    if is_gunicorn:
+        # Use Gunicorn's logger for production
+        gunicorn_logger = logging.getLogger("gunicorn.error")
+        for handler in gunicorn_logger.handlers:
+            handler.setFormatter(formatter)
+            app.logger.addHandler(handler)
+        app.logger.setLevel(logging.INFO)
+        app.logger.info("Production logging configured (using Gunicorn logger)")
+    else:
+        # Create a handler that writes to stdout
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(formatter)
+        app.logger.addHandler(console_handler)
+        app.logger.setLevel(logging.DEBUG if app.debug else logging.INFO)
+        app.logger.info("Development logging configured")
 
 
 app = create_app()
-celery.conf.update(app.config)
-app.extensions["celery"] = celery
 
-if __name__ != "__main__":
-    gunicorn_logger = logging.getLogger("gunicorn.error")
-    app.logger.handlers = gunicorn_logger.handlers
-    app.logger.setLevel(logging.INFO)
+# Initialize cache
+with app.app_context():
+    from api.services.cache_service import initialize_cache_refresh_scheduler
 
-limiter.init_app(app)
-db.init_app(app)
-swagger.init_app(app)
+    try:
+        app.logger.info("Setting up cache refresh scheduler")
+        initial_refresh_func = initialize_cache_refresh_scheduler(hours=3)
+        refresh_success = initial_refresh_func()
+        if not refresh_success:
+            app.logger.warning("Initial TLE cache refresh was not successful")
+    except Exception as e:
+        app.logger.error(f"Error during cache initialization: {e}", exc_info=True)

--- a/src/api/adapters/database_orm.py
+++ b/src/api/adapters/database_orm.py
@@ -9,9 +9,11 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.orm import DeclarativeBase, relationship
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass
 
 
 class SatelliteDb(Base):

--- a/src/api/adapters/repositories/satellite_repository.py
+++ b/src/api/adapters/repositories/satellite_repository.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Optional
 
 from sqlalchemy import func
 
@@ -14,7 +15,7 @@ class AbstractSatelliteRepository(abc.ABC):
         self._add(satellite)
         self.seen.add(satellite)
 
-    def get(self, satellite_id: str) -> Satellite:
+    def get(self, satellite_id: str) -> Optional[Satellite]:
         satellite = self._get(satellite_id)
         if satellite:
             self.seen.add(satellite)
@@ -32,11 +33,11 @@ class AbstractSatelliteRepository(abc.ABC):
     def get_satellite_data_by_name(self, name):
         return self._get_satellite_data_by_name(name)
 
-    def get_active_satellites(self, object_type: str = None):
+    def get_active_satellites(self, object_type: Optional[str] = None):
         return self._get_active_satellites(object_type)
 
     @abc.abstractmethod
-    def _get(self, satellite_id: str) -> Satellite:
+    def _get(self, satellite_id: str) -> Optional[Satellite]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -60,7 +61,7 @@ class AbstractSatelliteRepository(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _get_active_satellites(self, object_type: str = None):
+    def _get_active_satellites(self, object_type: Optional[str] = None):
         raise NotImplementedError
 
 
@@ -69,7 +70,7 @@ class SqlAlchemySatelliteRepository(AbstractSatelliteRepository):
         super().__init__()
         self.session = session
 
-    def _get(self, satellite_id: str) -> Satellite:
+    def _get(self, satellite_id: str) -> Optional[Satellite]:
         orm_satellite = (
             self.session.query(SatelliteDb)
             .filter(SatelliteDb.sat_number == satellite_id)
@@ -177,7 +178,7 @@ class SqlAlchemySatelliteRepository(AbstractSatelliteRepository):
 
         return satellite
 
-    def _get_active_satellites(self, object_type: str = None):
+    def _get_active_satellites(self, object_type: Optional[str] = None):
         """
         Retrieves active satellites based on the provided object type (optional).
         Only returns satellites that are active (no decay date) and have current
@@ -208,7 +209,7 @@ class SqlAlchemySatelliteRepository(AbstractSatelliteRepository):
 
     # SQLAlchemyRepository-specific methods
     @staticmethod
-    def _to_domain(orm_satellite):
+    def _to_domain(orm_satellite) -> Optional[Satellite]:
         if orm_satellite is None:
             return None
         return Satellite(

--- a/src/api/changes/tle_cache.changed.md
+++ b/src/api/changes/tle_cache.changed.md
@@ -1,0 +1,1 @@
+Cache most recent TLE set for use with FOV queries from the current time either into the future or up to 3 hours into the past. If cache is inaccessible for any reason, it defaults to a regular database query.

--- a/src/api/changes/type.misc.md
+++ b/src/api/changes/type.misc.md
@@ -1,0 +1,1 @@
+Added type checking to linting part of GitHub actions (and associated changes to address type checking errors

--- a/src/api/common/exceptions.py
+++ b/src/api/common/exceptions.py
@@ -1,8 +1,14 @@
+from typing import Optional
+
+
 class ValidationError(Exception):
     """Exception raised for validation errors."""
 
     def __init__(
-        self, status_code: int, message: str, original_exception: Exception = None
+        self,
+        status_code: int,
+        message: str,
+        original_exception: Optional[Exception] = None,
     ):
         self.message = message
         self.status_code = status_code
@@ -14,7 +20,10 @@ class DataError(Exception):
     """Exception raised for data related errors."""
 
     def __init__(
-        self, status_code: int, message: str, original_exception: Exception = None
+        self,
+        status_code: int,
+        message: str,
+        original_exception: Optional[Exception] = None,
     ):
         self.message = message
         self.status_code = status_code

--- a/src/api/common/position_data_point.py
+++ b/src/api/common/position_data_point.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 position_data_point = namedtuple(
-    "data_point",
+    "position_data_point",
     [
         "ra",
         "dec",

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -38,11 +38,11 @@ def get_db_login():
 
     if os.environ.get("DB_HOST") is not None:
         username, password, host, port, dbname = (
-            os.environ.get("DB_USERNAME"),
-            os.environ.get("DB_PASSWORD"),
-            os.environ.get("DB_HOST"),
-            os.environ.get("DB_PORT"),
-            os.environ.get("DB_NAME"),
+            os.environ.get("DB_USERNAME", ""),
+            os.environ.get("DB_PASSWORD", ""),
+            os.environ.get("DB_HOST", ""),
+            os.environ.get("DB_PORT", ""),
+            os.environ.get("DB_NAME", ""),
         )
         return [username, password, host, port, dbname]
 

--- a/src/api/domain/models/satellite.py
+++ b/src/api/domain/models/satellite.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 
 class Satellite:
@@ -6,12 +7,12 @@ class Satellite:
         self,
         sat_number: int,
         sat_name: str,
-        constellation: str = None,
-        rcs_size: str = None,
-        launch_date: datetime = None,
-        decay_date: datetime = None,
-        object_id: str = None,
-        object_type: str = None,
+        constellation: Optional[str] = None,
+        rcs_size: Optional[str] = None,
+        launch_date: Optional[datetime] = None,
+        decay_date: Optional[datetime] = None,
+        object_id: Optional[str] = None,
+        object_type: Optional[str] = None,
         has_current_sat_number: bool = False,
     ):
         self.sat_number = sat_number

--- a/src/api/entrypoints/extensions.py
+++ b/src/api/entrypoints/extensions.py
@@ -10,7 +10,7 @@ from flask_sqlalchemy import SQLAlchemy
 from redis import Redis
 
 
-def get_forwarded_address():
+def get_forwarded_address() -> str:
     """
     Retrieves the original IP address from the 'X-Forwarded-For' header of a
     HTTP request.
@@ -29,7 +29,7 @@ def get_forwarded_address():
     forwarded_header = request.headers.get("X-Forwarded-For")
     if forwarded_header:
         return request.headers.getlist("X-Forwarded-For")[0]
-    return get_remote_address
+    return get_remote_address()
 
 
 db = SQLAlchemy()
@@ -47,8 +47,8 @@ if redis_url and "://" in redis_url:
     else:
         # Parse standard URLs
         parsed = urlparse(redis_url)
-        redis_host = parsed.hostname
-        redis_port = parsed.port
+        redis_host = parsed.hostname or "localhost"
+        redis_port = parsed.port or 6379
 else:
     # Use separate host/port env vars
     redis_host = os.getenv("REDIS_HOST", "localhost")

--- a/src/api/entrypoints/v1/routes/__init__.py
+++ b/src/api/entrypoints/v1/routes/__init__.py
@@ -5,3 +5,7 @@ api_main = Blueprint("api_main", __name__)
 
 api_source = "IAU CPS SatChecker"
 api_version = "1.3.1"
+
+# Import all route modules to register the routes with the blueprints
+# This ensures all routes are registered when the blueprints are imported elsewhere
+from . import ephemeris_routes, fov_routes, routes, tools_routes  # noqa: E402, F401

--- a/src/api/entrypoints/v1/routes/fov_routes.py
+++ b/src/api/entrypoints/v1/routes/fov_routes.py
@@ -226,7 +226,9 @@ def get_satellite_passes():
         required_parameters = ["site", "duration", "ra", "dec", "fov_radius"]
 
     try:
-        parameters = validate_parameters(request, parameters, required_parameters)
+        validated_parameters = validate_parameters(
+            request, parameters, required_parameters
+        )
     except ValidationError as e:
         abort(e.status_code, e.message)
 
@@ -236,15 +238,15 @@ def get_satellite_passes():
     try:
         satellite_passes = get_satellite_passes_in_fov(
             tle_repo,
-            parameters["location"],
-            parameters["mid_obs_time_jd"],
-            parameters["start_time_jd"],
-            parameters["duration"],
-            parameters["ra"],
-            parameters["dec"],
-            parameters["fov_radius"],
-            parameters["group_by"],
-            parameters["include_tles"],
+            validated_parameters["location"],
+            validated_parameters["mid_obs_time_jd"],
+            validated_parameters["start_time_jd"],
+            validated_parameters["duration"],
+            validated_parameters["ra"],
+            validated_parameters["dec"],
+            validated_parameters["fov_radius"],
+            validated_parameters["group_by"],
+            validated_parameters["include_tles"],
             api_source,
             api_version,
         )
@@ -545,7 +547,9 @@ def _handle_satellites_above_horizon(with_duration=False):
         required_parameters.append("duration")
 
     try:
-        parameters = validate_parameters(request, parameters, required_parameters)
+        validated_parameters = validate_parameters(
+            request, parameters, required_parameters
+        )
     except ValidationError as e:
         abort(e.status_code, e.message)
 
@@ -558,13 +562,13 @@ def _handle_satellites_above_horizon(with_duration=False):
             """
             satellite_passes = get_satellites_above_horizon_range(
                 tle_repo,
-                parameters["location"],
-                parameters["julian_dates"],
-                parameters["min_altitude"],
-                parameters["min_range"],
-                parameters["max_range"],
-                parameters["illuminated_only"],
-                parameters["duration"],
+                validated_parameters["location"],
+                validated_parameters["julian_dates"],
+                validated_parameters["min_altitude"],
+                validated_parameters["min_range"],
+                validated_parameters["max_range"],
+                validated_parameters["illuminated_only"],
+                validated_parameters["duration"],
                 api_source,
                 api_version,
             )
@@ -573,12 +577,12 @@ def _handle_satellites_above_horizon(with_duration=False):
         else:
             satellite_passes = get_satellites_above_horizon(
                 tle_repo,
-                parameters["location"],
-                parameters["julian_dates"],
-                parameters["min_altitude"],
-                parameters["min_range"],
-                parameters["max_range"],
-                parameters["illuminated_only"],
+                validated_parameters["location"],
+                validated_parameters["julian_dates"],
+                validated_parameters["min_altitude"],
+                validated_parameters["min_range"],
+                validated_parameters["max_range"],
+                validated_parameters["illuminated_only"],
                 api_source,
                 api_version,
             )

--- a/src/api/entrypoints/v1/routes/tools_routes.py
+++ b/src/api/entrypoints/v1/routes/tools_routes.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E501
+import io
 from datetime import datetime, timezone
 
 from flask import abort, jsonify, request, send_file
@@ -541,7 +542,7 @@ def get_tles_at_epoch():
     page = int(parameters.get("page", 1) or 1)
     per_page = int(parameters.get("per_page") or 100)
 
-    tles = get_all_tles_at_epoch_formatted(
+    result = get_all_tles_at_epoch_formatted(
         tle_repo,
         epoch_date,
         format=format,
@@ -551,17 +552,17 @@ def get_tles_at_epoch():
         api_version=api_version,
     )
 
-    if format == "txt":
-        return send_file(tles, mimetype="text/plain", as_attachment=False)
-    elif format == "zip":
+    if format == "txt" and isinstance(result, io.BytesIO):
+        return send_file(result, mimetype="text/plain", as_attachment=False)
+    elif format == "zip" and isinstance(result, io.BytesIO):
         return send_file(
-            tles,
+            result,
             mimetype="application/zip",
             as_attachment=True,
             download_name="tle_data.zip",
         )
     else:
-        return jsonify(tles)
+        return jsonify(result)
 
 
 @api_v1.route("/tools/get-nearest-tle/")

--- a/src/api/middleware/error_handler.py
+++ b/src/api/middleware/error_handler.py
@@ -1,20 +1,11 @@
 import logging
-import sys
 import traceback
 from datetime import datetime, timezone
 
 from flask import jsonify, request
-from werkzeug.exceptions import HTTPException
 
-# Basic stdout logging
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-)
-
-logger = logging.getLogger("error_handler")
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+# Use the application's centralized logging configuration
+logger = logging.getLogger(__name__)
 
 
 def handle_error(error):
@@ -63,10 +54,6 @@ def handle_error(error):
 def init_error_handler(app):
     """Register error handlers with Flask app"""
     logger.info("Registering error handler")
-    # Register for all HTTP exceptions
-    app.register_error_handler(HTTPException, handle_error)
-    # Register for validation errors
+
+    # Register for all exceptions
     app.register_error_handler(Exception, handle_error)
-    # Register specific error codes
-    for code in [400, 404, 429, 500]:
-        app.register_error_handler(code, handle_error)

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -76,7 +76,7 @@ matplotlib-inline==0.1.6
 mccabe==0.7.0
 mdurl==0.1.2
 mistune==3.0.1
-mypy==1.6.1
+mypy==1.15.0
 mypy-extensions==1.0.0
 myst-parser==4.0.1
 nbclient==0.8.0

--- a/src/api/satchecker.py
+++ b/src/api/satchecker.py
@@ -1,1 +1,6 @@
-from api import app, celery  # noqa: F401, I001
+"""SatChecker application runner."""
+
+from api import app
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/src/api/services/cache_service.py
+++ b/src/api/services/cache_service.py
@@ -1,0 +1,304 @@
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from astropy.coordinates import EarthLocation
+from astropy.time import Time
+
+from api.entrypoints.extensions import db, redis_client, scheduler
+
+# Use the application's centralized logging configuration
+logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TTL = 3600  # 1 hour in seconds
+RECENT_TLES_CACHE_KEY = "recent_tles"
+
+
+def create_fov_cache_key(
+    location: EarthLocation,
+    mid_obs_time_jd: Time,
+    start_time_jd: Time,
+    duration: float,
+    ra: float,
+    dec: float,
+    fov_radius: float,
+    include_tles: bool = False,
+) -> str:
+    """Create a unique cache key for the FOV calculation."""
+    key_parts = [
+        "fov",
+        f"lat_{location.lat.value:.6f}",
+        f"lon_{location.lon.value:.6f}",
+        f"height_{location.height.value:.6f}",
+        f"mid_time_{mid_obs_time_jd.jd if mid_obs_time_jd else 'None'}",
+        f"start_time_{start_time_jd.jd if start_time_jd else 'None'}",
+        f"duration_{duration}",
+        f"ra_{ra}",
+        f"dec_{dec}",
+        f"radius_{fov_radius}",
+        f"include_tles_{include_tles}",
+    ]
+    return ":".join(key_parts)
+
+
+def get_cached_data(key: str, default: Any = None) -> Any:
+    """Get data from cache
+    Args:
+        key: The cache key to retrieve the data for.
+        default: The default value to return if the data is not found in the cache.
+    Returns:
+        The deserialized data from the cache or the default value if the data is not
+        found in the cache.
+    """
+    if not redis_client:
+        return default
+
+    try:
+        data = redis_client.get(key)
+        if not data:
+            return default
+        return json.loads(data)
+    except Exception as e:
+        logger.warning(f"Cache retrieval error for key {key}: {e}")
+        return default
+
+
+def set_cached_data(key: str, data: Any, ttl: int = DEFAULT_CACHE_TTL) -> bool:
+    """Set data in cache with default or custom TTL.
+    Args:
+        key: The cache key to set the data for.
+        data: The unserialized data to set in the cache.
+        ttl: The time-to-live for the cache entry.
+    Returns:
+        True if the data was set successfully, False otherwise.
+    """
+    if not redis_client:
+        return False
+
+    try:
+        serialized = json.dumps(data)
+        redis_client.setex(key, ttl, serialized)
+        return True
+    except Exception as e:
+        logger.warning(f"Cache set error for key {key}: {e}")
+        return False
+
+
+def batch_serialize_tles(tles):
+    """
+    Efficiently serialize a batch of TLEs for caching.
+    Much faster than serializing one by one, especially for large datasets.
+
+    Args:
+        tles: List of TLE objects to serialize
+
+    Returns:
+        List of serialized TLE dictionaries
+    """
+    # Pre-allocate result array for better performance
+    result = []
+    result_append = result.append  # Local reference to improve loops
+
+    for tle in tles:
+        # Get satellite information once to avoid repeated attribute access
+        satellite = tle.satellite
+        decay_date = satellite.decay_date
+
+        # Create efficient TLE dictionary with direct attribute access
+        tle_dict = {
+            "tle_line1": tle.tle_line1,
+            "tle_line2": tle.tle_line2,
+            "epoch": tle.epoch.isoformat(),
+            "date_collected": tle.date_collected.isoformat(),
+            "is_supplemental": tle.is_supplemental,
+            "data_source": tle.data_source,
+            "satellite": {
+                "sat_name": satellite.sat_name,
+                "sat_number": satellite.sat_number,
+                "decay_date": decay_date.isoformat() if decay_date else None,
+                "has_current_sat_number": getattr(
+                    satellite, "has_current_sat_number", True
+                ),
+            },
+        }
+        result_append(tle_dict)
+
+    return result
+
+
+def refresh_tle_cache(session=None):
+    """
+    Refresh the TLE cache with current data from the database.
+    Can be used both for initialization and scheduled updates.
+
+    Args:
+        session: Optional database session to use. If None, db.session will be used,
+                which requires a Flask application context.
+    """
+    from api.adapters.repositories.tle_repository import SqlAlchemyTLERepository
+
+    # Track if we created a new session that needs to be closed
+    created_new_session = False
+
+    try:
+        logger.info(f"Refreshing TLE cache at {datetime.now(timezone.utc)}")
+
+        # Create a new db session if one wasn't provided
+        if session is None:
+            from flask import current_app
+
+            if not current_app:
+                logger.error("No Flask app context available and no session provided")
+                return False
+
+            session = db.session
+            created_new_session = False  # db.session is managed by Flask
+
+        tle_repo = SqlAlchemyTLERepository(session)
+
+        # Current time as the epoch date
+        epoch_date = datetime.now(timezone.utc)
+
+        # Perform full TLE retrieval
+        logger.info("Retrieving TLEs from database...")
+        tles, count, _ = tle_repo._get_all_tles_at_epoch(epoch_date, 1, 100000, "json")
+        logger.info(f"Retrieved {count} TLEs from database")
+
+        # Serialize TLEs for JSON storage
+        logger.info(f"Serializing {len(tles)} TLEs for caching")
+        try:
+            # Use the batch serialization for all TLEs
+            serialized_tles = batch_serialize_tles(tles)
+            logger.info(f"Successfully serialized {len(serialized_tles)} TLEs")
+        except Exception as e:
+            logger.error(f"Batch serialization failed: {e}", exc_info=True)
+            return False
+
+        # Cache the result
+        cache_data = {
+            "tles": serialized_tles,  # Use serialized TLEs
+            "total_count": count,
+            "cached_at": epoch_date.isoformat(),
+        }
+
+        # Set TTL to 3 hours
+        ttl = 3 * 3600
+        logger.info(f"Setting cache with TTL of {ttl} seconds")
+        cache_result = set_cached_data(RECENT_TLES_CACHE_KEY, cache_data, ttl=ttl)
+
+        if cache_result:
+            logger.info(f"TLE cache refreshed with {len(serialized_tles)} entries")
+        else:
+            logger.warning("TLE data retrieved but caching failed")
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Error refreshing TLE cache: {e}", exc_info=True)
+        # Roll back any pending transactions
+        if session and session.is_active:
+            session.rollback()
+        return False
+
+    finally:
+        # Close session if we created it
+        if created_new_session and session:
+            session.close()
+
+
+# Define a global function for the scheduler to use
+def scheduled_cache_refresh_job():
+    """Global function for the scheduler job to refresh the cache"""
+    try:
+        # Access the Flask app directly through the scheduler
+
+        app = scheduler.app
+
+        logger.info(
+            f"Scheduled TLE cache refresh triggered at {datetime.now(timezone.utc)}"
+        )
+
+        # Execute refresh_tle_cache within the app context
+        with app.app_context():
+            logger.info("Running scheduled refresh with app context")
+            refresh_tle_cache()
+    except Exception as e:
+        logger.error(f"Error in scheduled TLE refresh: {e}", exc_info=True)
+
+
+# Global flag to track if the initial refresh has been done
+_initial_cache_refresh_done = False
+
+
+def initialize_cache_refresh_scheduler(hours=3):
+    """Set up a scheduled job to refresh TLE cache every X hours"""
+    global _initial_cache_refresh_done
+
+    # Use a fixed job ID that's easier to check
+    job_id = "cache_refresh_task"
+
+    existing_jobs = scheduler.get_jobs()
+    job_exists = any(job.id == job_id for job in existing_jobs)
+
+    if job_exists:
+        logger.info(
+            f"Cache refresh scheduler job '{job_id}' already exists, not adding again"
+        )
+    else:
+        try:
+            # Add the job using the global function instead of a closure
+            scheduler.add_job(
+                func=scheduled_cache_refresh_job,
+                trigger="interval",
+                id=job_id,
+                hours=hours,
+                misfire_grace_time=900,  # 15 min grace time
+                replace_existing=True,  # Replace if it somehow exists
+            )
+            logger.info(
+                f"Added cache refresh scheduler job '{job_id}' "
+                f"with interval {hours} hours"
+            )
+        except Exception as e:
+            logger.error(f"Failed to schedule cache refresh job: {e}")
+
+    # Don't perform immediate refresh here, as it might not have app context
+    def perform_initial_refresh():
+        """Performs the initial cache refresh with proper app context"""
+        global _initial_cache_refresh_done
+
+        # Prevent duplicate initial refresh
+        if _initial_cache_refresh_done:
+            logger.info("Initial refresh already performed, skipping")
+            return True
+
+        try:
+            from flask import Flask, current_app
+
+            if not current_app:
+                logger.warning(
+                    "No Flask app context available for initial cache refresh"
+                )
+                return False
+
+            # Get the app from the current_app proxy
+            app = current_app._get_current_object()
+
+            if not isinstance(app, Flask):
+                logger.warning("Current app is not a Flask instance")
+                return False
+
+            with app.app_context():
+                # Create a new session within the app context
+                session = db.session
+                logger.info("Performing initial TLE cache refresh")
+                result = refresh_tle_cache(session=session)
+                _initial_cache_refresh_done = True
+                return result
+
+        except Exception as e:
+            logger.error(f"Error during initial TLE cache refresh: {e}", exc_info=True)
+            return False
+
+    return perform_initial_refresh

--- a/src/api/services/ephemeris_service.py
+++ b/src/api/services/ephemeris_service.py
@@ -1,3 +1,5 @@
+from typing import Any, Union
+
 from astropy.coordinates import EarthLocation
 from astropy.time import Time, TimeDelta
 
@@ -22,7 +24,7 @@ def generate_ephemeris_data(
     api_version: str,
     data_source: str = "",
     propagation_method: str = "skyfield",
-) -> list[dict]:
+) -> Union[dict[str, Any], list[dict[str, Any]]]:
 
     #  get TLE from repository
     tle = (
@@ -63,7 +65,7 @@ def generate_ephemeris_data(
             propagation_method,
         ]
     )
-    result_list = result_list_task.get()
+    result_list: Union[dict[str, Any], list[dict[str, Any]]] = result_list_task.get()
     return result_list
 
 
@@ -75,7 +77,7 @@ def generate_ephemeris_data_user(
     max_altitude: float,
     api_source: str,
     api_version: str,
-) -> list[dict]:
+) -> Union[dict[str, Any], list[dict[str, Any]]]:
 
     result_list_task = generate_position_data.apply(
         args=[
@@ -95,5 +97,5 @@ def generate_ephemeris_data_user(
             tle.data_source,
         ]
     )
-    result_list = result_list_task.get()
+    result_list: Union[dict[str, Any], list[dict[str, Any]]] = result_list_task.get()
     return result_list

--- a/src/api/services/fov_service.py
+++ b/src/api/services/fov_service.py
@@ -1,5 +1,6 @@
 import time as python_time
 from datetime import datetime
+from typing import Any
 
 import numpy as np
 from astropy.coordinates import EarthLocation
@@ -29,7 +30,7 @@ def get_satellite_passes_in_fov(
     include_tles: bool,
     api_source: str,
     api_version: str,
-) -> dict:
+) -> dict[str, Any]:
     start_time = python_time.time()
     print(f"\nStarting FOV calculation at: {datetime.now().isoformat()}")
     print(f"FOV Parameters: RA={ra}°, Dec={dec}°, Radius={fov_radius}°")
@@ -106,7 +107,7 @@ def get_satellite_passes_in_fov(
     all_results = []
     satellites_processed = 0
     points_in_fov = 0
-    total_sat_time = 0
+    total_sat_time = 0.0
 
     for tle in tles:
         sat_start = python_time.time()
@@ -237,7 +238,7 @@ def get_satellites_above_horizon(
     illuminated_only: bool = False,
     api_source: str = "",
     api_version: str = "",
-) -> dict:
+) -> dict[str, Any]:
     """
     Get all satellites above the horizon at a specific time.
 

--- a/src/api/services/fov_service.py
+++ b/src/api/services/fov_service.py
@@ -1,6 +1,5 @@
-import json
 import time as python_time
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import numpy as np
 from astropy.coordinates import EarthLocation
@@ -8,35 +7,13 @@ from astropy.time import Time
 from skyfield.api import EarthSatellite, load, wgs84
 
 from api.adapters.repositories.tle_repository import AbstractTLERepository
-from api.entrypoints.extensions import redis_client
+from api.services.cache_service import (
+    create_fov_cache_key,
+    get_cached_data,
+    set_cached_data,
+)
 from api.utils import coordinate_systems, output_utils
-
-
-def _create_fov_cache_key(
-    location: EarthLocation,
-    mid_obs_time_jd: Time,
-    start_time_jd: Time,
-    duration: float,
-    ra: float,
-    dec: float,
-    fov_radius: float,
-    include_tles: bool = False,
-) -> str:
-    """Create a unique cache key for the FOV calculation."""
-    key_parts = [
-        "fov",
-        f"lat_{location.lat.value:.6f}",
-        f"lon_{location.lon.value:.6f}",
-        f"height_{location.height.value:.6f}",
-        f"mid_time_{mid_obs_time_jd.jd if mid_obs_time_jd else 'None'}",
-        f"start_time_{start_time_jd.jd if start_time_jd else 'None'}",
-        f"duration_{duration}",
-        f"ra_{ra}",
-        f"dec_{dec}",
-        f"radius_{fov_radius}",
-        f"include_tles_{include_tles}",
-    ]
-    return ":".join(key_parts)
+from api.utils.time_utils import astropy_time_to_datetime_utc
 
 
 def get_satellite_passes_in_fov(
@@ -60,7 +37,7 @@ def get_satellite_passes_in_fov(
 
     # Create cache key and check cache
 
-    cache_key = _create_fov_cache_key(
+    cache_key = create_fov_cache_key(
         location,
         mid_obs_time_jd,
         start_time_jd,
@@ -70,18 +47,18 @@ def get_satellite_passes_in_fov(
         fov_radius,
         False if include_tles is None else include_tles,
     )
-    cached_data = redis_client.get(cache_key)
+
+    cached_data = get_cached_data(cache_key)
     if cached_data:
         cache_time = python_time.time() - start_time
         print("Found cached result")
-        cached_results = json.loads(cached_data)
         # Return cached results using the same formatting function
         return output_utils.fov_data_to_json(
-            cached_results["results"],
-            cached_results["points_in_fov"],
+            cached_data["results"],
+            cached_data["points_in_fov"],
             {
                 "total_time": round(cache_time, 3),
-                "points_in_fov": cached_results["points_in_fov"],
+                "points_in_fov": cached_data["points_in_fov"],
                 "from_cache": True,
             },
             api_source,
@@ -92,8 +69,8 @@ def get_satellite_passes_in_fov(
     # Get all current TLEs
     tle_start = python_time.time()
     time_param = mid_obs_time_jd if mid_obs_time_jd is not None else start_time_jd
-    tles, count = tle_repo.get_all_tles_at_epoch(
-        time_param.to_datetime(), 1, 10000, "zip"
+    tles, count, _ = tle_repo.get_all_tles_at_epoch(
+        astropy_time_to_datetime_utc(time_param), 1, 10000, "zip"
     )
 
     tle_time = python_time.time() - tle_start
@@ -245,7 +222,7 @@ def get_satellite_passes_in_fov(
         "results": all_results,
         "points_in_fov": points_in_fov,
     }
-    redis_client.setex(cache_key, timedelta(hours=1), json.dumps(cache_data))
+    set_cached_data(cache_key, cache_data)
 
     return result
 
@@ -282,7 +259,9 @@ def get_satellites_above_horizon(
 
     # Get all current TLEs
     tle_start = python_time.time()
-    tles, count = tle_repo.get_all_tles_at_epoch(time_jd.to_datetime(), 1, 10000, "zip")
+    tles, count, _ = tle_repo.get_all_tles_at_epoch(
+        astropy_time_to_datetime_utc(time_jd), 1, 10000, "zip"
+    )
     tle_time = python_time.time() - tle_start
 
     # Set up time and observer

--- a/src/api/services/tasks/ephemeris_tasks.py
+++ b/src/api/services/tasks/ephemeris_tasks.py
@@ -1,11 +1,11 @@
 import logging
+from typing import Any, Union
 
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from flask import current_app, has_app_context
 
 from api.celery_app import celery
-from api.common.position_data_point import position_data_point
 
 # from core import celery, utils
 from api.utils.output_utils import position_data_to_json
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @celery.task
 def process_results(
-    data_points: list[tuple[float, float]],
+    data_points: list[tuple[float, ...]],
     min_altitude: float,
     max_altitude: float,
     date_collected: str,
@@ -32,7 +32,7 @@ def process_results(
     data_source: str,
     api_source: str,
     api_version: str,
-) -> list[position_data_point]:
+) -> dict[str, Any]:
     """
     Process the results of the satellite propagation.
 
@@ -50,7 +50,8 @@ def process_results(
         data_source (str): The data source.
 
     Returns:
-        list[position_data_point]: The processed results.
+        dict[str, Any]: Either the processed results dictionary or an
+        info message dictionary.
     """
     if has_app_context():
         current_app.logger.info("process results started")
@@ -67,7 +68,7 @@ def process_results(
         }
 
     # Add remaining metadata to results
-    data_set = position_data_to_json(
+    data_set: dict[str, Any] = position_data_to_json(
         name,
         intl_designator,
         catalog_id,
@@ -100,7 +101,7 @@ def generate_position_data(
     catalog_id: str = "",
     data_source: str = "",
     propagation_strategy: str = "skyfield",
-) -> list[dict]:
+) -> Union[dict[str, Any], list[dict[str, Any]]]:
     """
     Create a list of results for a given satellite and date range.
 
@@ -121,7 +122,8 @@ def generate_position_data(
         data_source (str, optional): The data source of the TLE data. Defaults to "".
 
     Returns:
-        list[dict]: A list of results for the given satellite and date range.
+        Union[dict[str, Any], list[dict[str, Any]]]: Either a dictionary with results
+        or a list of results for the given satellite and date range.
     """
     # Create a chord that will propagate the satellite for
     # each date and then process the results
@@ -161,10 +163,11 @@ def generate_position_data(
             api_version,
         ]
     )
-    results = processed_results.get()
-    if not results:
-        return {"info": "No position information found with this criteria"}
-    return results
+    result_dict: dict[str, Any] = processed_results.get()
+    if not result_dict:
+        return [{"info": "No position information found with this criteria"}]
+
+    return result_dict
 
 
 @celery.task

--- a/src/api/services/tasks/ephemeris_tasks.py
+++ b/src/api/services/tasks/ephemeris_tasks.py
@@ -4,7 +4,7 @@ from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from flask import current_app, has_app_context
 
-from api import celery
+from api.celery_app import celery
 from api.common.position_data_point import position_data_point
 
 # from core import celery, utils

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -376,7 +376,7 @@ def get_all_tles_at_epoch_formatted(
     actual_per_page = 1000000 if format == "txt" else per_page
     actual_page = 1 if format == "txt" else page
 
-    tles, total_count = tle_repo.get_all_tles_at_epoch(
+    tles, total_count, _ = tle_repo.get_all_tles_at_epoch(
         epoch_date, actual_page, actual_per_page, format
     )
 

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -2,7 +2,7 @@ import csv
 import io
 import zipfile
 from datetime import datetime
-from typing import Union
+from typing import Any, Optional, Union
 
 from api.adapters.repositories.satellite_repository import AbstractSatelliteRepository
 from api.adapters.repositories.tle_repository import AbstractTLERepository
@@ -94,7 +94,16 @@ def get_tles_around_epoch_results(
     Returns:
         List[dict]: A list of dictionaries containing the TLE data.
     """
-    tles = tle_repo.get_tles_around_epoch(id, id_type, epoch, count_before, count_after)
+    tles_result = tle_repo.get_tles_around_epoch(
+        id, id_type, epoch, count_before, count_after
+    )
+
+    # Ensure tles is a list to avoid iteration errors
+    tles = (
+        []
+        if tles_result is None
+        else tles_result if isinstance(tles_result, list) else [tles_result]
+    )
 
     # Extract the TLE data from the result set
     tle_data = [
@@ -126,7 +135,7 @@ def get_nearest_tle_result(
     epoch: datetime,
     api_source: str,
     api_version: str,
-) -> list[dict[str, str | int | None]]:
+) -> list[dict[str, Union[list[dict[str, Any]], str]]]:
     """
     Fetches the nearest TLE to a specific epoch date.
 
@@ -142,15 +151,18 @@ def get_nearest_tle_result(
         api_version (str): The version of the API request.
 
     Returns:
-        list[dict[str, str | int | None]]: A single-item list containing a
-        dictionary with:
-        - satellite_name (str): Name of the satellite
-        - satellite_id (int): NORAD catalog number
-        - tle_line1 (str): First line of the TLE
-        - tle_line2 (str): Second line of the TLE
-        - epoch (str): Epoch of the TLE in 'YYYY-MM-DD HH:MM:SS TZ' format
-        - date_collected (str): Date TLE was collected
-        - data_source (str): Source of the TLE data
+        list[dict[str, Union[list[dict[str, Any]], str]]]: A single-item list
+        containing a dictionary with:
+        - tle_data: List of dictionaries, each containing:
+            - satellite_name (str): Name of the satellite
+            - satellite_id (int): NORAD catalog number
+            - tle_line1 (str): First line of the TLE
+            - tle_line2 (str): Second line of the TLE
+            - epoch (str): Epoch of the TLE in 'YYYY-MM-DD HH:MM:SS TZ' format
+            - date_collected (str): Date TLE was collected
+            - data_source (str): Source of the TLE data
+        - source (str): API source identifier
+        - version (str): API version identifier
     """
     tle = tle_repo.get_nearest_tle(id, id_type, epoch)
 
@@ -186,7 +198,8 @@ def get_adjacent_tle_results(
     epoch: datetime,
     api_source: str,
     api_version: str,
-):
+    format: str = "json",
+) -> Union[list[dict[str, Union[list[dict[str, Any]], str]]], io.BytesIO]:
     """
     Fetches the adjacent TLEs to a specific epoch date - one TLE before and one after.
 
@@ -195,14 +208,18 @@ def get_adjacent_tle_results(
         id (str): The ID of the satellite.
         id_type (str): The type of the ID, either "catalog" or "name".
         epoch (datetime): The epoch date to fetch the adjacent TLEs to.
-        format (str): The format of the TLE data, either "json" or "txt".
+        api_source (str): The source of the API request.
+        api_version (str): The version of the API request.
+        format (str): The format of the response, either "json" or "txt".
     Returns:
-        List[dict]: A list of dictionaries containing the TLE data.
+        Union[list[dict[str, Union[list[dict[str, Any]], str]]], io.BytesIO]:
+            - For JSON format: A list containing a dictionary with TLE data
+            - For TXT format: A BytesIO object containing the formatted TLE text
     """
     tles = tle_repo.get_adjacent_tles(id, id_type, epoch)
 
     if format == "txt":
-        tle_data = [
+        tle_data: list[str] = [
             f"{tle.satellite.sat_name}\n{tle.tle_line1}\n{tle.tle_line2}\n"
             for tle in tles
         ]
@@ -211,7 +228,7 @@ def get_adjacent_tle_results(
 
     else:
         # Extract the TLE data from the result set
-        tle_data = [
+        tle_json_data = [
             {
                 "satellite_name": tle.satellite.sat_name,
                 "satellite_id": tle.satellite.sat_number,
@@ -226,7 +243,7 @@ def get_adjacent_tle_results(
 
         return [
             {
-                "tle_data": tle_data,
+                "tle_data": tle_json_data,
                 "source": api_source,
                 "version": api_version,
             }
@@ -293,7 +310,7 @@ def get_satellite_data(
 
 def get_active_satellites(
     sat_repo: AbstractSatelliteRepository,
-    object_type: str,
+    object_type: Optional[str],
     api_source: str,
     api_version: str,
 ):
@@ -354,7 +371,7 @@ def get_all_tles_at_epoch_formatted(
     per_page: int = 100,
     api_source: str = "",
     api_version: str = "",
-) -> Union[list, io.BytesIO]:
+) -> Union[list[dict[str, Any]], io.BytesIO]:
     """
     Fetches all TLEs at a specific epoch date with support for different output formats.
 
@@ -368,9 +385,9 @@ def get_all_tles_at_epoch_formatted(
         api_version (str): The version of the API request.
 
     Returns:
-        Union[list, io.BytesIO]: Either a list containing TLE data and pagination info
-                                (JSON) or a BytesIO object containing formatted TLE data
-                                (TXT/ZIP).
+        Union[list[dict[str, Any]], io.BytesIO]: Either a list containing TLE data
+        and pagination info (JSON) or a BytesIO object containing formatted TLE data
+        (TXT/ZIP).
     """
     # For text format, get all records
     actual_per_page = 1000000 if format == "txt" else per_page
@@ -381,7 +398,7 @@ def get_all_tles_at_epoch_formatted(
     )
 
     if format == "txt":
-        tle_data = [
+        tle_data: list[str] = [
             f"{tle.satellite.sat_name}\n{tle.tle_line1}\n{tle.tle_line2}\n"
             for tle in tles
         ]
@@ -426,7 +443,7 @@ def get_all_tles_at_epoch_formatted(
 
     else:
         # Format as JSON
-        tle_data = [
+        tle_json_data = [
             {
                 "satellite_name": tle.satellite.sat_name,
                 "satellite_id": tle.satellite.sat_number,
@@ -444,7 +461,7 @@ def get_all_tles_at_epoch_formatted(
                 "per_page": per_page,
                 "page": page,
                 "total_results": total_count,
-                "data": tle_data,
+                "data": tle_json_data,
                 "source": api_source,
                 "version": api_version,
             }

--- a/src/api/utils/coordinate_systems.py
+++ b/src/api/utils/coordinate_systems.py
@@ -290,7 +290,7 @@ def icrf2radec(pos, unit_vector=False, deg=True):
     modulo = np.mod
     pix2 = 2.0 * np.pi
 
-    r = 1
+    r = 1.0
     if pos.ndim > 1:
         if not unit_vector:
             r = norm(pos, axis=1)
@@ -299,7 +299,7 @@ def icrf2radec(pos, unit_vector=False, deg=True):
         zu = pos[:, 2] / r
     else:
         if not unit_vector:
-            r = norm(pos)
+            r = float(norm(pos))
         xu = pos[0] / r
         yu = pos[1] / r
         zu = pos[2] / r
@@ -378,8 +378,8 @@ def tle_to_icrf_state(tle_line_1, tle_line_2, jd):
             state. If 0, the function will use the epoch specified in the TLE set.
 
     Returns:
-        np.array: A 1D array containing the ICRF position (in km) and velocity (in km/s)
-            of the satellite.
+        np.ndarray: A 1D array containing the ICRF position (in km) and velocity
+        (in km/s) of the satellite.
     """
 
     tle_line_1 = tle_line_1.strip().replace("%20", " ")
@@ -404,7 +404,7 @@ def tle_to_icrf_state(tle_line_1, tle_line_2, jd):
     return np.concatenate(np.array([r, v]))
 
 
-def is_illuminated(sat_gcrs: np.array, julian_date: float) -> bool:
+def is_illuminated(sat_gcrs: np.ndarray, julian_date: float) -> bool:
     """
     Determines if a satellite is illuminated by the sun.
 
@@ -412,7 +412,7 @@ def is_illuminated(sat_gcrs: np.array, julian_date: float) -> bool:
     the satellite is illuminated.
 
     Parameters:
-        sat_gcrs (np.array): The position of the satellite in the GCRS frame.
+        sat_gcrs (np.ndarray): The position of the satellite in the GCRS frame.
         julian_date (float): The Julian date to check if the satellite is illuminated.
 
     Returns:
@@ -488,7 +488,7 @@ def get_earth_sun_positions(t: float | Time) -> tuple[np.ndarray, np.ndarray]:
 
 
 def get_phase_angle(
-    topocentric_gcrs_norm: np.array, sat_gcrs: np.array, julian_date: float
+    topocentric_gcrs_norm: np.ndarray, sat_gcrs: np.ndarray, julian_date: float
 ) -> float:
     """
     Computes the phase angle between a satellite and the Sun as seen from Earth.
@@ -498,9 +498,9 @@ def get_phase_angle(
     The phase angle is useful in determining the illumination of the satellite.
 
     Args:
-        topocentric_gcrs_norm (np.array): Normalized vector representing the
+        topocentric_gcrs_norm (np.ndarray): Normalized vector representing the
                                           topocentric position in GCRS coordinates.
-        sat_gcrs (np.array): Vector representing the satellite's position in
+        sat_gcrs (np.ndarray): Vector representing the satellite's position in
                              GCRS coordinates.
         julian_date (float): The Julian date at which to compute the phase angle.
 
@@ -513,5 +513,5 @@ def get_phase_angle(
     satsun = sat_gcrs - earthsun
     satsunn = satsun / np.linalg.norm(satsun)
 
-    phase_angle = np.rad2deg(np.arccos(np.dot(satsunn, topocentric_gcrs_norm)))
+    phase_angle = float(np.rad2deg(np.arccos(np.dot(satsunn, topocentric_gcrs_norm))))
     return phase_angle

--- a/src/api/utils/output_utils.py
+++ b/src/api/utils/output_utils.py
@@ -1,4 +1,5 @@
 from datetime import timezone
+from typing import Any
 
 import numpy as np
 from astropy.time import Time
@@ -152,7 +153,7 @@ def fov_data_to_json(
     group_by: str,
     precision_angles=8,
     precision_date=8,
-) -> dict:
+) -> dict[str, Any]:
     """Convert FOV results to JSON format with optional grouping by satellite.
 
     Args:
@@ -238,7 +239,7 @@ def fov_data_to_json(
         # Original chronological format
         formatted_results = {
             "data": results,
-            "count": len(results),
+            "count": len(results),  # type: ignore[dict-item]
             "performance": performance_metrics,
             "source": api_source,
             "version": api_version,

--- a/src/api/utils/output_utils.py
+++ b/src/api/utils/output_utils.py
@@ -197,12 +197,19 @@ def fov_data_to_json(
             sat_key = f"{sat_name} ({sat_norad_id})"
 
             if sat_key not in satellites:
-                satellites[sat_key] = {
+                # Create base satellite dictionary
+                satellite_dict = {
                     "name": sat_name,
                     "norad_id": sat_norad_id,
                     "positions": [],
-                    "tle_data": result.get("tle_data"),
                 }
+
+                # Only add tle_data if it's not null/empty
+                tle_data = result.get("tle_data")
+                if tle_data is not None and tle_data != {}:
+                    satellite_dict["tle_data"] = tle_data
+
+                satellites[sat_key] = satellite_dict
             # Add pass data without redundant satellite info
             pass_data = {
                 "ra": result["ra"],

--- a/src/api/utils/propagation_strategies.py
+++ b/src/api/utils/propagation_strategies.py
@@ -402,6 +402,8 @@ class TestPropagationStrategy:
             ddistance,
             phase_angle,
             illuminated,
+            None,  # satellite_gcrs
+            None,  # observer_gcrs
             jd.jd,
         )
 

--- a/src/api/utils/time_utils.py
+++ b/src/api/utils/time_utils.py
@@ -1,4 +1,7 @@
+from datetime import timezone
+
 import numpy as np
+from astropy.time import Time
 
 
 def jd_to_gst(jd: float, nutation: float) -> float:
@@ -90,3 +93,21 @@ def calculate_lst(longitude: float, jd: float) -> float:
     lst = np.radians(lst_deg)
 
     return lst
+
+
+def astropy_time_to_datetime_utc(time_obj: Time):
+    """
+    Convert an astropy Time object to a timezone-aware Python datetime (UTC).
+
+    Args:
+        time_obj: Astropy Time object to convert
+
+    Returns:
+        datetime.datetime object with UTC timezone
+    """
+    # Make sure the time object is in UTC scale before converting
+    # to datetime with timezone
+    if time_obj.scale != "utc":
+        time_obj = time_obj.utc
+
+    return time_obj.to_datetime(timezone=timezone.utc)

--- a/src/api/utils/time_utils.py
+++ b/src/api/utils/time_utils.py
@@ -1,4 +1,4 @@
-from datetime import timezone
+from datetime import datetime, timezone
 
 import numpy as np
 from astropy.time import Time
@@ -48,7 +48,8 @@ def jd_to_gst(jd: float, nutation: float) -> float:
     # Convert to radians
     theta_gast = np.deg2rad(theta_gast)
 
-    return theta_gast
+    # Ensure we return a Python float, not a NumPy type
+    return float(theta_gast)
 
 
 def calculate_lst(longitude: float, jd: float) -> float:
@@ -92,10 +93,11 @@ def calculate_lst(longitude: float, jd: float) -> float:
     # Convert LST from degrees to radians
     lst = np.radians(lst_deg)
 
-    return lst
+    # Ensure we return a Python float, not a NumPy type
+    return float(lst)
 
 
-def astropy_time_to_datetime_utc(time_obj: Time):
+def astropy_time_to_datetime_utc(time_obj: Time) -> datetime:
     """
     Convert an astropy Time object to a timezone-aware Python datetime (UTC).
 
@@ -110,4 +112,6 @@ def astropy_time_to_datetime_utc(time_obj: Time):
     if time_obj.scale != "utc":
         time_obj = time_obj.utc
 
-    return time_obj.to_datetime(timezone=timezone.utc)
+    # Explicitly cast to datetime to satisfy the type checker
+    dt: datetime = time_obj.to_datetime(timezone=timezone.utc)
+    return dt

--- a/tests/benchmark/test_fov_benchmark.py
+++ b/tests/benchmark/test_fov_benchmark.py
@@ -83,7 +83,7 @@ class MockTLERepository(AbstractTLERepository):
         return matching_tles[0]  # Just return the first one for simplicity in testing
 
     def _get_all_tles_at_epoch(self, epoch_date, page, per_page, format):
-        return self.mock_tles, len(self.mock_tles)
+        return self.mock_tles, len(self.mock_tles), "database"
 
     def _get_adjacent_tles(self, id, id_type, epoch):
         matching_tles = [tle for tle in self.mock_tles if tle.satellite.sat_id == id]
@@ -307,7 +307,7 @@ def test_benchmark_get_satellites_above_horizon_setup(
     def setup_only():
         # This replicates what happens at the beginning of get_satellites_above_horizon
         time_jd = mid_obs_time
-        tles, count = mock_tle_repository._get_all_tles_at_epoch(
+        tles, count, _ = mock_tle_repository._get_all_tles_at_epoch(
             time_jd.to_datetime(), 1, 10000, "zip"
         )
         all_results = []

--- a/tests/unit/test_fov_service.py
+++ b/tests/unit/test_fov_service.py
@@ -292,7 +292,8 @@ def test_fov_caching_cycle(mocker, test_location, test_time):
         fake_cache[key] = value
         return True
 
-    mock_redis_client = mocker.patch("api.services.fov_service.redis_client")
+    # Mock redis_client in cache_service instead of fov_service
+    mock_redis_client = mocker.patch("api.services.cache_service.redis_client")
     mock_redis_client.get.side_effect = mock_get
     mock_redis_client.setex.side_effect = mock_setex
 
@@ -358,7 +359,7 @@ def test_fov_cache_key_consistency(mocker, test_location, test_time):
     # Use a set to collect and compare cache keys
     cache_keys = set()
 
-    mock_redis_client = mocker.patch("api.services.fov_service.redis_client")
+    mock_redis_client = mocker.patch("api.services.cache_service.redis_client")
     mock_redis_client.get.return_value = None
 
     tle_repo = FakeTLERepository([])
@@ -388,7 +389,7 @@ def test_fov_cache_key_consistency(mocker, test_location, test_time):
 
 def test_fov_different_cache_keys(mocker, test_location, test_time):
     """Test that different parameters generate different cache keys."""
-    mock_redis_client = mocker.patch("api.services.fov_service.redis_client")
+    mock_redis_client = mocker.patch("api.services.cache_service.redis_client")
     mock_redis_client.get.return_value = None
 
     tle_repo = FakeTLERepository([])

--- a/tests/unit/test_validation_service.py
+++ b/tests/unit/test_validation_service.py
@@ -402,7 +402,7 @@ def test_parse_tle():
             2 25544  51.6416 290.4299 0005730  30.7454 132.9751 15.50238117414255"
     result = parse_tle(tle)
     assert result.satellite.sat_name == "ISS (ZARYA)"
-    assert result.satellite.sat_number == "25544"
+    assert result.satellite.sat_number == 25544
     assert (
         result.tle_line1
         == "1 25544U 98067A   23248.54842295  .00012769  00000+0  22936-3 0  9997"


### PR DESCRIPTION
### Description:
Cache the most recently retrieved TLE set for use with FOV queries either into the future or within the last 3 hours of the current time - reverts to the DB query if cache is unavailable. 
Also add mypy to the run_tests workflow and fix type-related errors to support that

### Context:
This should speed up predictive FOV queries without requiring as much work/overhead to find a solution that works for the entire TLE history

JIRA issue: [SCK-107](https://noirlab.atlassian.net/browse/SCK-107)

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
