### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/radon_complexity.yml
+++ b/.github/workflows/radon_complexity.yml
@@ -1,5 +1,8 @@
 name: Radon Code Complexity Analysis
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     # This allows the workflow to be called by other workflows


### PR DESCRIPTION
Add a `permissions` block at the root of the workflow file. 


