### PR TITLE
Add parameter to FOV queries to only show satellites that are illuminated

### DIFF
--- a/docs/source/fov.rst
+++ b/docs/source/fov.rst
@@ -28,6 +28,7 @@ Satellite passes Through FOV
    :query include_tles: (*optional*) -- If True, include TLE data used to calculate the passes in the response. Default is False.
    :query constellation: (*optional*) -- Constellation name (e.g. 'starlink') - if provided, only satellites from this constellation will be returned.
    :query data_source: (*optional*) -- Data source to use for TLEs ("celestrak", "spacetrack", or "any"). Default is "any".
+   :query is_illuminated: (*optional*) -- If True, only return satellites that are illuminated. Default is False.
 
 **Example Request**
     .. tabs::

--- a/docs/source/fov.rst
+++ b/docs/source/fov.rst
@@ -28,7 +28,7 @@ Satellite passes Through FOV
    :query include_tles: (*optional*) -- If True, include TLE data used to calculate the passes in the response. Default is False.
    :query constellation: (*optional*) -- Constellation name (e.g. 'starlink') - if provided, only satellites from this constellation will be returned.
    :query data_source: (*optional*) -- Data source to use for TLEs ("celestrak", "spacetrack", or "any"). Default is "any".
-   :query is_illuminated: (*optional*) -- If True, only return satellites that are illuminated. Default is False.
+   :query illuminated_only: (*optional*) -- If True, only return satellites that are illuminated. Default is False.
 
 **Example Request**
     .. tabs::

--- a/src/api/changes/163.feature.md
+++ b/src/api/changes/163.feature.md
@@ -1,0 +1,1 @@
+Added `illuminated_only` parameter to FOV endpoints to filter satellites based on expected solar illumination status.

--- a/src/api/entrypoints/v1/routes/fov_routes.py
+++ b/src/api/entrypoints/v1/routes/fov_routes.py
@@ -125,7 +125,7 @@ def get_satellite_passes():
         required: false
         description: Data source to use for TLEs ("celestrak" or "spacetrack"). Default is any/all sources.
         example: "celestrak"
-      - name: is_illuminated
+      - name: illuminated_only
         in: query
         type: boolean
         required: false
@@ -236,7 +236,7 @@ def get_satellite_passes():
         "skip_cache",
         "constellation",
         "data_source",
-        "is_illuminated",
+        "illuminated_only",
     ]
 
     if "site" not in request.args:
@@ -272,7 +272,7 @@ def get_satellite_passes():
             validated_parameters["skip_cache"],
             validated_parameters["constellation"],
             validated_parameters["data_source"],
-            validated_parameters["is_illuminated"],
+            validated_parameters["illuminated_only"],
             api_source,
             api_version,
         )
@@ -370,12 +370,6 @@ def get_all_satellites_above_horizon():
         required: false
         description: Constellation of the satellites to include in the response
         example: "starlink"
-      - name: is_illuminated
-        in: query
-        type: boolean
-        required: false
-        description: Whether to include only illuminated satellites (default is false)
-        example: true
     responses:
       200:
         description: Successful response with satellites above horizon
@@ -521,12 +515,6 @@ def get_all_satellites_above_horizon_range():
         required: false
         description: Maximum range of satellites in kilometers (default is infinity)
         example: 500.0
-      - name: is_illuminated
-        in: query
-        type: boolean
-        required: false
-        description: Whether to include only illuminated satellites (default is false)
-        example: true
     responses:
       200:
         description: Successful response with satellites above horizon during the specified period
@@ -575,7 +563,6 @@ def _handle_satellites_above_horizon(with_duration=False):
         "min_range",
         "max_range",
         "constellation",
-        "is_illuminated",
     ]
 
     # Add duration parameter if needed
@@ -625,7 +612,6 @@ def _handle_satellites_above_horizon(with_duration=False):
                 validated_parameters["max_range"],
                 validated_parameters["illuminated_only"],
                 validated_parameters["constellation"],
-                validated_parameters["is_illuminated"],
                 api_source,
                 api_version,
             )

--- a/src/api/entrypoints/v1/routes/fov_routes.py
+++ b/src/api/entrypoints/v1/routes/fov_routes.py
@@ -125,6 +125,12 @@ def get_satellite_passes():
         required: false
         description: Data source to use for TLEs ("celestrak" or "spacetrack"). Default is any/all sources.
         example: "celestrak"
+      - name: is_illuminated
+        in: query
+        type: boolean
+        required: false
+        description: Whether to include only illuminated satellites (default is false)
+        example: true
     responses:
       200:
         description: Successful response with satellite passes
@@ -230,6 +236,7 @@ def get_satellite_passes():
         "skip_cache",
         "constellation",
         "data_source",
+        "is_illuminated",
     ]
 
     if "site" not in request.args:
@@ -265,6 +272,7 @@ def get_satellite_passes():
             validated_parameters["skip_cache"],
             validated_parameters["constellation"],
             validated_parameters["data_source"],
+            validated_parameters["is_illuminated"],
             api_source,
             api_version,
         )
@@ -362,6 +370,12 @@ def get_all_satellites_above_horizon():
         required: false
         description: Constellation of the satellites to include in the response
         example: "starlink"
+      - name: is_illuminated
+        in: query
+        type: boolean
+        required: false
+        description: Whether to include only illuminated satellites (default is false)
+        example: true
     responses:
       200:
         description: Successful response with satellites above horizon
@@ -507,6 +521,12 @@ def get_all_satellites_above_horizon_range():
         required: false
         description: Maximum range of satellites in kilometers (default is infinity)
         example: 500.0
+      - name: is_illuminated
+        in: query
+        type: boolean
+        required: false
+        description: Whether to include only illuminated satellites (default is false)
+        example: true
     responses:
       200:
         description: Successful response with satellites above horizon during the specified period
@@ -555,6 +575,7 @@ def _handle_satellites_above_horizon(with_duration=False):
         "min_range",
         "max_range",
         "constellation",
+        "is_illuminated",
     ]
 
     # Add duration parameter if needed
@@ -604,6 +625,7 @@ def _handle_satellites_above_horizon(with_duration=False):
                 validated_parameters["max_range"],
                 validated_parameters["illuminated_only"],
                 validated_parameters["constellation"],
+                validated_parameters["is_illuminated"],
                 api_source,
                 api_version,
             )

--- a/src/api/services/fov_service.py
+++ b/src/api/services/fov_service.py
@@ -35,6 +35,7 @@ def get_satellite_passes_in_fov(
     skip_cache: bool,
     constellation: str,
     data_source: str,
+    is_illuminated: bool,
     api_source: str,
     api_version: str,
 ) -> dict[str, Any]:
@@ -54,6 +55,8 @@ def get_satellite_passes_in_fov(
         include_tles: Whether to include TLE data in results
         skip_cache: Whether to skip cache and force recalculation
         constellation: Constellation of the satellites to include in the response
+        data_source: Data source for TLEs
+        is_illuminated: Whether to include only illuminated satellites
         api_source: Source of the API call
         api_version: Version of the API
 
@@ -200,6 +203,7 @@ def get_satellite_passes_in_fov(
             fov_radius=fov_radius,
             batch_size=250,
             include_tles=include_tles,
+            is_illuminated=is_illuminated,
         )
 
         # Add all valid results to the final output

--- a/src/api/services/fov_service.py
+++ b/src/api/services/fov_service.py
@@ -35,7 +35,7 @@ def get_satellite_passes_in_fov(
     skip_cache: bool,
     constellation: str,
     data_source: str,
-    is_illuminated: bool,
+    illuminated_only: bool,
     api_source: str,
     api_version: str,
 ) -> dict[str, Any]:
@@ -56,7 +56,7 @@ def get_satellite_passes_in_fov(
         skip_cache: Whether to skip cache and force recalculation
         constellation: Constellation of the satellites to include in the response
         data_source: Data source for TLEs
-        is_illuminated: Whether to include only illuminated satellites
+        illuminated_only: Whether to include only illuminated satellites
         api_source: Source of the API call
         api_version: Version of the API
 
@@ -203,7 +203,7 @@ def get_satellite_passes_in_fov(
             fov_radius=fov_radius,
             batch_size=250,
             include_tles=include_tles,
-            is_illuminated=is_illuminated,
+            illuminated_only=illuminated_only,
         )
 
         # Add all valid results to the final output

--- a/src/api/utils/coordinate_systems.py
+++ b/src/api/utils/coordinate_systems.py
@@ -468,11 +468,11 @@ def is_illuminated_vectorized(
     Returns:
         list[bool]: List of illumination states for each satellite position.
     """
-    if len(sat_gcrs_list) != len(julian_dates):
-        raise ValueError("sat_gcrs_list and julian_dates must have the same length")
-
     if not sat_gcrs_list:
         return []
+
+    if len(sat_gcrs_list) != len(julian_dates):
+        raise ValueError("sat_gcrs_list and julian_dates must have the same length")
 
     # Convert to numpy arrays for vectorized operations
     sat_gcrs_array = np.array(sat_gcrs_list)

--- a/src/api/utils/propagation_strategies.py
+++ b/src/api/utils/propagation_strategies.py
@@ -613,7 +613,7 @@ def process_satellite_batch(args):
         fov_center,
         fov_radius,
         include_tles,
-        is_illuminated,
+        illuminated_only,
     ) = args
 
     # Convert single date to list for consistent handling
@@ -644,7 +644,7 @@ def process_satellite_batch(args):
             # Vectorized angle calculation
             sat_fov_angles = np.arccos(np.sum(topocentricn * icrf, axis=0))
             in_fov_mask = np.degrees(sat_fov_angles) < fov_radius
-            if is_illuminated:
+            if illuminated_only:
                 # run is_illuminated for each julian date so we can
                 # only show points that are illuminated
                 sat_gcrs = [
@@ -716,7 +716,7 @@ class FOVParallelPropagationStrategy:
         batch_size=1000,
         max_workers=None,
         include_tles=True,
-        is_illuminated=False,
+        illuminated_only=False,
     ) -> tuple[list[dict[str, Any]], float, int]:
         """
         Propagate satellite positions and check if they fall within FOV.
@@ -769,7 +769,7 @@ class FOVParallelPropagationStrategy:
                 fov_center,
                 fov_radius,
                 include_tles,
-                is_illuminated,
+                illuminated_only,
             )
             for batch in satellite_batches
         ]

--- a/src/api/utils/propagation_strategies.py
+++ b/src/api/utils/propagation_strategies.py
@@ -28,6 +28,7 @@ from api.utils.coordinate_systems import (
     get_phase_angle,
     icrf2radec,
     is_illuminated,
+    is_illuminated_vectorized,
     itrs_to_gcrs,
     teme_to_ecef,
 )
@@ -645,12 +646,11 @@ def process_satellite_batch(args):
             sat_fov_angles = np.arccos(np.sum(topocentricn * icrf, axis=0))
             in_fov_mask = np.degrees(sat_fov_angles) < fov_radius
             if illuminated_only:
-                # run is_illuminated for each julian date so we can
                 # only show points that are illuminated
                 sat_gcrs = [
                     satellite.at(ts.ut1_jd(jd)).position.km for jd in julian_dates
                 ]
-                illuminated = [is_illuminated(sat_gcrs, jd) for jd in julian_dates]
+                illuminated = is_illuminated_vectorized(sat_gcrs, julian_dates)
                 visible_mask = np.logical_and(in_fov_mask, illuminated)
             else:
                 visible_mask = in_fov_mask

--- a/tests/unit/test_fov_service.py
+++ b/tests/unit/test_fov_service.py
@@ -49,6 +49,7 @@ def test_satellite_in_fov(test_location, test_time):
         include_tles=False,
         skip_cache=False,
         constellation=None,
+        illuminated_only=False,
         data_source="any",
         api_source="test",
         api_version="1.0",
@@ -72,6 +73,7 @@ def test_satellite_in_fov(test_location, test_time):
         skip_cache=False,
         constellation=None,
         data_source=None,
+        illuminated_only=False,
         api_source="test",
         api_version="1.0",
     )
@@ -105,6 +107,7 @@ def test_satellite_in_fov(test_location, test_time):
         skip_cache=False,
         constellation=None,
         data_source=None,
+        illuminated_only=False,
         api_source="test",
         api_version="1.0",
     )
@@ -127,6 +130,7 @@ def test_satellite_in_fov(test_location, test_time):
         skip_cache=False,
         constellation=None,
         data_source="any",
+        illuminated_only=False,
         api_source="test",
         api_version="1.0",
     )
@@ -175,6 +179,7 @@ def test_satellite_outside_fov(test_location, test_time):
         skip_cache=False,
         constellation=None,
         data_source="any",
+        illuminated_only=False,
         api_source="test",
         api_version="1.0",
     )
@@ -201,6 +206,7 @@ def test_empty_tle_list(test_location, test_time):
         skip_cache=False,
         constellation=None,
         data_source=None,
+        illuminated_only=False,
         api_source="test",
         api_version="1.0",
     )

--- a/tests/unit/test_fov_service.py
+++ b/tests/unit/test_fov_service.py
@@ -49,8 +49,8 @@ def test_satellite_in_fov(test_location, test_time):
         include_tles=False,
         skip_cache=False,
         constellation=None,
-        illuminated_only=False,
         data_source="any",
+        illuminated_only=False,
         api_source="test",
         api_version="1.0",
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -210,7 +210,7 @@ def test_process_satellite_batch():
     assert result[0][0]["ra"] == pytest.approx(23.95167273, rel=1e-9)
     assert result[0][0]["dec"] == pytest.approx(75.60577991, rel=1e-9)
 
-    illuminated_only = False
+    illuminated_only = True
     args = (
         tle_batch,
         julian_dates,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -607,6 +607,60 @@ def test_is_illuminated():
         is_illuminated = coordinate_systems.is_illuminated(sat_gcrs, julian_date)
 
 
+def test_is_illuminated_vectorized():
+    # should be illuminated
+    sat_gcrs = np.array([-1807.4145165806299, -5481.865083864486, 3817.782079208943])
+    julian_date = 2460546.599502
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert is_illuminated[0]
+
+    sat_gcrs = np.array([-1726.6525239983253, -5556.764988629915, 3732.6312069408664])
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert is_illuminated[0]
+
+    sat_gcrs = np.array([-2788.9344500353254, -6082.063324305135, 1780.452113395069])
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert is_illuminated[0]
+
+    sat_gcrs = np.array([-6285.693766146678, -2883.510160329265, 372.90511732453666])
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert is_illuminated[0]
+
+    # should not be illuminated
+    sat_gcrs = np.array([2148.476260974862, -5720.341032518884, 3250.5047622565057])
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert not is_illuminated[0]
+
+    sat_gcrs = np.array([1239.1815032279183, -6748.906100431373, 1012.4062279591224])
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert not is_illuminated[0]
+
+    sat_gcrs = np.array([-145.69690994172956, -6807.470474898967, 877.3659084400132])
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [sat_gcrs], [julian_date]
+    )
+    assert not is_illuminated[0]
+
+    # with error
+    sat_gcrs = np.array([1.0, 0.0])
+    with pytest.raises(ValueError):
+        is_illuminated = coordinate_systems.is_illuminated_vectorized(
+            [sat_gcrs], [julian_date]
+        )
+
+
 def test_ensure_datetime():
     # Test date string in YYYY-MM-DD format
     date_str = "2025-01-01"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -192,6 +192,7 @@ def test_process_satellite_batch():
     fov_center = (24.797270, 75.774139)
     fov_radius = 2.0
     include_tles = True
+    illuminated_only = False
 
     args = (
         tle_batch,
@@ -202,6 +203,7 @@ def test_process_satellite_batch():
         fov_center,
         fov_radius,
         include_tles,
+        illuminated_only,
     )
     result = process_satellite_batch(args)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -210,6 +210,23 @@ def test_process_satellite_batch():
     assert result[0][0]["ra"] == pytest.approx(23.95167273, rel=1e-9)
     assert result[0][0]["dec"] == pytest.approx(75.60577991, rel=1e-9)
 
+    illuminated_only = False
+    args = (
+        tle_batch,
+        julian_dates,
+        latitude,
+        longitude,
+        elevation,
+        fov_center,
+        fov_radius,
+        include_tles,
+        illuminated_only,
+    )
+    result = process_satellite_batch(args)
+
+    assert result[0][0]["ra"] == pytest.approx(23.95167273, rel=1e-9)
+    assert result[0][0]["dec"] == pytest.approx(75.60577991, rel=1e-9)
+
 
 def test_skyfield_propagation_strategy():
     julian_date = 2459000.5
@@ -656,11 +673,16 @@ def test_is_illuminated_vectorized():
     assert not is_illuminated[0]
 
     # with error
-    sat_gcrs = np.array([1.0, 0.0])
+    sat_gcrs = [1, 2, 3, 4]
     with pytest.raises(ValueError):
         is_illuminated = coordinate_systems.is_illuminated_vectorized(
-            [sat_gcrs], [julian_date]
+            sat_gcrs, [julian_date]
         )
+
+    is_illuminated = coordinate_systems.is_illuminated_vectorized(
+        [], [julian_date, julian_date]
+    )
+    assert is_illuminated == []
 
 
 def test_ensure_datetime():


### PR DESCRIPTION
### Description:
FOV queries now have an optional parameter to show only satellites that are expected to not be illuminated at during that time (or more specifically, position points that are expected to be illuminated, since that can change as a satellite crosses overhead). The default value for this parameter is False.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
