### PR TITLE
Use :slim base image to reduce image file size.

### DIFF
--- a/src/api/Dockerfile.celery
+++ b/src/api/Dockerfile.celery
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.11
+FROM --platform=linux/amd64 docker.io/python:3.11-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
### Description:

In the interest of resource efficiency, I'm proposing the use of the `slim` variant of the `python` base image.
