### PR TITLE
Add equivalent OMM element generation to replace TLE generation

### DIFF
--- a/docs/source/fov.rst
+++ b/docs/source/fov.rst
@@ -30,7 +30,7 @@ Satellite passes Through FOV
    :query dec: (*required*) -- Declination of FOV center in degrees
    :query fov_radius: (*required*) -- Radius of circular FOV in degrees
    :query group_by: (*optional*) -- How to group results ("satellite" or "time"). Default is "time" for chronological order
-   :query include_tles: (*optional*) -- If True, include TLE data used to calculate the passes in the response. Default is False.
+   :query include_orbital_data: (*optional*) -- If True, include TLE data used to calculate the passes in the response. Default is False.
    :query constellation: (*optional*) -- Constellation name (e.g. 'starlink') - if provided, only satellites from this constellation will be returned.
    :query data_source: (*optional*) -- Data source to use for TLEs ("celestrak", "spacetrack", or "any"). Default is "any".
    :query illuminated_only: (*optional*) -- If True, only return satellites that are illuminated. Default is False.

--- a/docs/source/tools_tle.rst
+++ b/docs/source/tools_tle.rst
@@ -250,7 +250,7 @@ check the epoch of the TLE to make sure that it is suitable for your needs.
         [
             {
                 "source": "IAU CPS SatChecker",
-                "tle_data": [
+                "orbital_data": [
                     {
                         "data_source": "spacetrack",
                         "date_collected": "2024-06-04 19:16:53 UTC",
@@ -324,7 +324,7 @@ by NORAD ID.
         [
             {
                 "source": "IAU CPS SatChecker",
-                "tle_data": [
+                "orbital_data": [
                     {
                         "data_source": "spacetrack",
                         "date_collected": "2024-11-26 17:37:22 UTC",
@@ -409,7 +409,7 @@ It currently only supports searching by NORAD ID.
         [
             {
                 "source": "IAU CPS SatChecker",
-                "tle_data": [
+                "orbital_data": [
                     {
                         "data_source": "spacetrack",
                         "date_collected": "2024-11-26 17:37:22 UTC",

--- a/src/api/changes/168.feature.md
+++ b/src/api/changes/168.feature.md
@@ -1,1 +1,1 @@
-Use operator-provided ephemeris data to interpolate satellite positions when available. This is only available for Starlink satellites. Covariance info for uncertainties is includd in the response, when ephemeris data is used.
+Use operator-provided ephemeris data to interpolate satellite positions when available. This is only available for Starlink satellites. Covariance info for uncertainties will be included in the response in the future.

--- a/src/api/changes/225.feature.md
+++ b/src/api/changes/225.feature.md
@@ -1,0 +1,5 @@
+Use orbital elements in OMM format from both Celestrak and Space-Track since Celestrak won't be using the alpha-5 notation for NORAD IDs to support the orginal TLE format.
+
+TLEs for dates before 2026-07-12 will continue to be used as is with no changes to any of the related endpoints, but OMM will be used for everything going forward.
+
+References to `tle_data` in API responses will be replaced with `orbital_data`. The ability to see which orbital data was used will be added in the future for the OMM format.

--- a/src/api/entrypoints/v1/routes/fov_routes.py
+++ b/src/api/entrypoints/v1/routes/fov_routes.py
@@ -109,7 +109,7 @@ def get_satellite_passes():
         description: Group results by 'satellite' or 'time' (default is 'time' for chronological order)
         enum: [satellite, time]
         example: satellite
-      - name: include_tles
+      - name: include_orbital_data
         in: query
         type: boolean
         required: false
@@ -223,7 +223,7 @@ def get_satellite_passes():
                                       description: Distance to the satellite in kilometers
                                     tle_data:
                                       type: object
-                                      description: TLE data for this satellite (only included when include_tles=true)
+                                      description: TLE data for this satellite (only included when include_orbital_data=true)
                                       properties:
                                         tle_line1:
                                           type: string
@@ -294,7 +294,7 @@ def get_satellite_passes():
         "start_time_jd",
         "mid_obs_time_jd",
         "group_by",
-        "include_tles",
+        "include_orbital_data",
         "skip_cache",
         "constellation",
         "data_source",
@@ -375,7 +375,7 @@ def get_satellite_passes():
                 validated_parameters["dec"],
                 validated_parameters["fov_radius"],
                 validated_parameters["group_by"],
-                validated_parameters["include_tles"],
+                validated_parameters["include_orbital_data"],
                 validated_parameters["skip_cache"],
                 validated_parameters["constellation"],
                 validated_parameters["data_source"],
@@ -399,7 +399,7 @@ def get_satellite_passes():
                 validated_parameters["dec"],
                 validated_parameters["fov_radius"],
                 validated_parameters["group_by"],
-                validated_parameters["include_tles"],
+                validated_parameters["include_orbital_data"],
                 validated_parameters["skip_cache"],
                 validated_parameters["constellation"],
                 validated_parameters["data_source"],

--- a/src/api/entrypoints/v1/routes/fov_routes.py
+++ b/src/api/entrypoints/v1/routes/fov_routes.py
@@ -221,7 +221,7 @@ def get_satellite_passes():
                                       type: number
                                       format: float
                                       description: Distance to the satellite in kilometers
-                                    tle_data:
+                                    orbital_data:
                                       type: object
                                       description: TLE data for this satellite (only included when include_orbital_data=true)
                                       properties:

--- a/src/api/services/cache_service.py
+++ b/src/api/services/cache_service.py
@@ -25,7 +25,7 @@ def create_fov_cache_key(
     ra: float,
     dec: float,
     fov_radius: float,
-    include_tles: bool = False,
+    include_orbital_data: bool = False,
     constellation: str | None = None,
     data_source: str | None = None,
 ) -> str:
@@ -41,7 +41,7 @@ def create_fov_cache_key(
         f"ra_{ra}",
         f"dec_{dec}",
         f"radius_{fov_radius}",
-        f"include_tles_{include_tles}",
+        f"include_orbital_data_{include_orbital_data}",
         f"constellation_{constellation}",
         f"data_source_{data_source}",
     ]

--- a/src/api/services/fov_service.py
+++ b/src/api/services/fov_service.py
@@ -58,7 +58,7 @@ def get_satellite_passes_in_fov_async(
     dec: float,
     fov_radius: float,
     group_by: str,
-    include_tles: bool,
+    include_orbital_data: bool,
     skip_cache: bool,
     constellation: str,
     data_source: str,
@@ -81,7 +81,7 @@ def get_satellite_passes_in_fov_async(
         mid_obs_time_jd,
         start_time_jd,
         group_by,
-        include_tles,
+        include_orbital_data,
         skip_cache,
     )
 
@@ -94,7 +94,7 @@ def get_satellite_passes_in_fov_async(
         ra,
         dec,
         fov_radius,
-        False if include_tles is None else include_tles,
+        False if include_orbital_data is None else include_orbital_data,
         constellation,
         data_source,
     )
@@ -165,7 +165,7 @@ def get_satellite_passes_in_fov_async(
         "location_height": float(location.height.value),
         "fov_center": (float(ra), float(dec)),
         "fov_radius": float(fov_radius),
-        "include_tles": include_tles,
+        "include_orbital_data": include_orbital_data,
         "illuminated_only": illuminated_only,
     }
 
@@ -230,7 +230,7 @@ def get_satellite_passes_in_fov(
     dec: float,
     fov_radius: float,
     group_by: str,
-    include_tles: bool,
+    include_orbital_data: bool,
     skip_cache: bool,
     constellation: str,
     data_source: str,
@@ -254,7 +254,7 @@ def get_satellite_passes_in_fov(
         dec: Declination of FOV center in degrees
         fov_radius: Radius of FOV in degrees
         group_by: Grouping strategy ('satellite' or 'time')
-        include_tles: Whether to include TLE data in results
+        include_orbital_data: Whether to include TLE data in results
         skip_cache: Whether to skip cache and force recalculation
         constellation: Constellation of the satellites to include in the response
         data_source: Data source for TLEs
@@ -278,7 +278,7 @@ def get_satellite_passes_in_fov(
         mid_obs_time_jd,
         start_time_jd,
         group_by,
-        include_tles,
+        include_orbital_data,
         skip_cache,
     )
 
@@ -291,7 +291,7 @@ def get_satellite_passes_in_fov(
         ra,
         dec,
         fov_radius,
-        False if include_tles is None else include_tles,
+        False if include_orbital_data is None else include_orbital_data,
         constellation,
         data_source,
     )
@@ -357,7 +357,7 @@ def get_satellite_passes_in_fov(
                 fov_center=(ra, dec),
                 fov_radius=fov_radius,
                 batch_size=250,
-                include_tles=include_tles,
+                include_orbital_data=include_orbital_data,
                 illuminated_only=illuminated_only,
             )
 
@@ -1086,7 +1086,7 @@ def _log_fov_parameters(
     mid_obs_time_jd: Time,
     start_time_jd: Time,
     group_by: str,
-    include_tles: bool,
+    include_orbital_data: bool,
     skip_cache: bool,
 ):
     logger.debug(f"Starting FOV calculation at: {datetime.now().isoformat()}")
@@ -1104,7 +1104,8 @@ def _log_fov_parameters(
         f"Time parameters: mid_obs_time={mid_obs_time_jd}, start_time={start_time_jd}"
     )
     logger.debug(
-        f"Group by: {group_by}, Include TLEs: {include_tles}, Skip cache: {skip_cache}"
+        f"Group by: {group_by}, Include TLEs: {include_orbital_data}, "
+        f"Skip cache: {skip_cache}"
     )
 
 

--- a/src/api/services/tasks/fov_tasks.py
+++ b/src/api/services/tasks/fov_tasks.py
@@ -38,7 +38,7 @@ def process_satellite_batch_task(
     location_height: float,
     fov_center: tuple[float, float],
     fov_radius: float,
-    include_tles: bool,
+    include_orbital_data: bool,
     illuminated_only: bool,
 ) -> tuple[list[dict[str, Any]], int, float]:
     """
@@ -56,7 +56,7 @@ def process_satellite_batch_task(
         location_height,
         fov_center,
         fov_radius,
-        include_tles,
+        include_orbital_data,
         illuminated_only,
     )
     return process_satellite_batch(args)

--- a/src/api/services/tools_service.py
+++ b/src/api/services/tools_service.py
@@ -166,7 +166,7 @@ def get_tles_around_epoch_results(
 
     return [
         {
-            "tle_data": tle_data,
+            "orbital_data": tle_data,
             "source": api_source,
             "version": api_version,
         }
@@ -242,7 +242,7 @@ def get_nearest_tle_result(
 
     return [
         {
-            "tle_data": tle_data,
+            "orbital_data": tle_data,
             "source": api_source,
             "version": api_version,
         }
@@ -313,7 +313,7 @@ def get_adjacent_tle_results(
             logger.info("Successfully formatted TLE data as JSON")
             return [
                 {
-                    "tle_data": tle_json_data,
+                    "orbital_data": tle_json_data,
                     "source": api_source,
                     "version": api_version,
                 }

--- a/src/api/services/validation_service.py
+++ b/src/api/services/validation_service.py
@@ -375,15 +375,20 @@ def validate_parameters(
                 + " group_by must be 'satellite' or 'time'",
             )
 
-    if "include_tles" in parameters.keys() and parameters["include_tles"] is not None:
-        if parameters["include_tles"].lower() not in ["true", "false"]:
+    if (
+        "include_orbital_data" in parameters.keys()
+        and parameters["include_orbital_data"] is not None
+    ):
+        if parameters["include_orbital_data"].lower() not in ["true", "false"]:
             raise ValidationError(
                 400,
                 error_messages.INVALID_PARAMETER
-                + " include_tles must be 'true' or 'false'",
+                + " include_orbital_data must be 'true' or 'false'",
             )
 
-        parameters["include_tles"] = parameters["include_tles"].lower() == "true"
+        parameters["include_orbital_data"] = (
+            parameters["include_orbital_data"].lower() == "true"
+        )
 
     if (
         "use_generated_tles" in parameters.keys()

--- a/src/api/utils/output_utils.py
+++ b/src/api/utils/output_utils.py
@@ -236,9 +236,9 @@ def fov_data_to_json(
                 }
 
                 # Only add tle_data if it's not null/empty
-                tle_data = result.get("tle_data")
+                tle_data = result.get("orbital_data")
                 if tle_data is not None and tle_data != {}:
-                    satellite_dict["tle_data"] = tle_data
+                    satellite_dict["orbital_data"] = tle_data
 
                 satellites[sat_key] = satellite_dict
             # Add pass data without redundant satellite info

--- a/src/api/utils/propagation_strategies.py
+++ b/src/api/utils/propagation_strategies.py
@@ -782,7 +782,7 @@ def process_satellite_batch(
 
                 # Only include TLE data if requested
                 if include_orbital_data and isinstance(orbital_data, TLE):
-                    result["include_orbital_data"] = {
+                    result["orbital_data"] = {
                         "tle_line1": orbital_data.tle_line1,
                         "tle_line2": orbital_data.tle_line2,
                         "source": orbital_data.data_source,

--- a/src/api/utils/propagation_strategies.py
+++ b/src/api/utils/propagation_strategies.py
@@ -700,7 +700,7 @@ def process_satellite_batch(
         elev,
         fov_center,
         fov_radius,
-        include_tles,
+        include_orbital_data,
         illuminated_only,
     ) = args
 
@@ -781,8 +781,8 @@ def process_satellite_batch(
                 }
 
                 # Only include TLE data if requested
-                if include_tles and isinstance(orbital_data, TLE):
-                    result["tle_data"] = {
+                if include_orbital_data and isinstance(orbital_data, TLE):
+                    result["include_orbital_data"] = {
                         "tle_line1": orbital_data.tle_line1,
                         "tle_line2": orbital_data.tle_line2,
                         "source": orbital_data.data_source,
@@ -855,7 +855,7 @@ class FOVParallelPropagationStrategy:
         fov_radius,
         batch_size=1000,
         max_workers=None,
-        include_tles=True,
+        include_orbital_data=True,
         illuminated_only=False,
         progress_callback=None,
         *,
@@ -873,7 +873,7 @@ class FOVParallelPropagationStrategy:
             fov_radius: FOV radius in degrees. Defaults to 0
             batch_size: Number of satellites to process in each batch
             max_workers: Maximum number of workers (in-process mode only)
-            include_tles: Whether to include TLE data in results
+            include_orbital_data: Whether to include TLE data in results
             illuminated_only: Whether to only include illuminated satellites
             progress_callback: Optional callback for progress updates
             batch_executor: Callable(serialized_batches, common_args) -> list of
@@ -915,7 +915,7 @@ class FOVParallelPropagationStrategy:
                 "location_height": elev,
                 "fov_center": fov_center,
                 "fov_radius": fov_radius,
-                "include_tles": include_tles,
+                "include_orbital_data": include_orbital_data,
                 "illuminated_only": illuminated_only,
             }
             batch_results = batch_executor(serialized_batches, common_args)
@@ -937,7 +937,7 @@ class FOVParallelPropagationStrategy:
                     elev,
                     fov_center,
                     fov_radius,
-                    include_tles,
+                    include_orbital_data,
                     illuminated_only,
                 )
                 for batch in satellite_batches

--- a/src/data/ephemeris_utils.py
+++ b/src/data/ephemeris_utils.py
@@ -13,8 +13,11 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import requests
 from frame_transforms import operator_position_frame_from_filename
+from orbital_data_generation import (
+    create_orbital_elements_from_ephemeris,
+    # create_tle_from_ephemeris,
+)
 from psycopg2.extras import execute_values
-from tle_generation import create_tle_from_ephemeris
 
 from api.domain.models.interpolable_ephemeris import (
     EphemerisPoint,
@@ -434,7 +437,7 @@ def get_starlink_ephemeris_data(cursor, connection):
        (``https://api.starlink.com/public-files/ephemerides``).
     2. Parses each file (``parse_ephemeris_file``), inserts the points into
        ``ephemeris_points`` (``insert_ephemeris_data``), and fits a generated
-       TLE from the first ``TLE_FIT_WINDOW_HOURS`` of stored data
+       OMM element set from the first ``ORBITAL_DATA_FIT_WINDOW_HOURS`` of stored data
        (````).
     3. After the loop, logs mean/median/p95/min/max for both TLE-fit timing
        and residuals across every ephemeris that was successfully processed.
@@ -521,21 +524,32 @@ def get_starlink_ephemeris_data(cursor, connection):
                 ephemeris, _ephemeris_id = insert_result
 
                 t0 = time.perf_counter()
-                fit_xyz_rms, fit_ang_rms = create_tle_from_ephemeris(
-                    ephemeris, cursor, connection
-                )
+                try:
+                    omm_xyz_rms, omm_ang_rms = create_orbital_elements_from_ephemeris(
+                        ephemeris, cursor, connection
+                    )
+                    if not (omm_xyz_rms == -1 and omm_ang_rms == -1):
+                        stats.append(
+                            {
+                                "orbital_data_generation_s": time.perf_counter() - t0,
+                                "fit_xyz_rms_km": omm_xyz_rms,
+                                "fit_ang_rms_arcsec": omm_ang_rms,
+                            }
+                        )
+                        total_data_points += len(ephemeris.points)
+                        files_processed += 1
+                except Exception as omm_err:
+                    logging.warning(
+                        "OMM generation failed for %s: %s", file_name, omm_err
+                    )
+                    try:
+                        connection.rollback()
+                    except Exception as rollback_err:
+                        logging.warning(
+                            "Rollback failed for %s: %s", file_name, rollback_err
+                        )
+                    cursor = connection.cursor()
 
-                if fit_xyz_rms == -1 and fit_ang_rms == -1:
-                    continue
-                stats.append(
-                    {
-                        "tle_generation_s": time.perf_counter() - t0,
-                        "fit_xyz_rms_km": fit_xyz_rms,
-                        "fit_ang_rms_arcsec": fit_ang_rms,
-                    }
-                )
-                total_data_points += len(ephemeris.points)
-                files_processed += 1
             except Exception as e:
                 logging.error("Error processing file %s: %s", file_name, e)
                 try:
@@ -549,15 +563,17 @@ def get_starlink_ephemeris_data(cursor, connection):
 
         logging.info("Total data points: %d", total_data_points)
         logging.info("Files processed: %d", files_processed)
-        _log_tle_generation_stats(stats)
+        _log_orbital_data_generation_stats(stats, label="OMM")
 
 
-def _log_tle_generation_stats(stats: list[dict[str, float]]) -> None:
+def _log_orbital_data_generation_stats(
+    stats: list[dict[str, float]], label: str = "OMM"
+) -> None:
     """Log mean/median/p95/min/max for timing and RMS across a batch."""
     if not stats:
         return
 
-    times = np.array([s["tle_generation_s"] for s in stats], dtype=float)
+    times = np.array([s["orbital_data_generation_s"] for s in stats], dtype=float)
     xyz_rms = np.array([s["fit_xyz_rms_km"] for s in stats], dtype=float)
     ang_rms = np.array([s["fit_ang_rms_arcsec"] for s in stats], dtype=float)
 
@@ -570,7 +586,7 @@ def _log_tle_generation_stats(stats: list[dict[str, float]]) -> None:
             float(np.max(values)),
         )
 
-    logging.info("TLE generation aggregate stats for %d ephemerides:", len(stats))
+    logging.info("%s generation aggregate stats for %d ephemerides:", label, len(stats))
     logging.info(
         "  Time (s):           mean=%.3f median=%.3f p95=%.3f min=%.3f max=%.3f",
         *_summary(times),

--- a/src/data/orbital_data_generation.py
+++ b/src/data/orbital_data_generation.py
@@ -6,6 +6,7 @@ import numpy as np
 from astropy.time import Time
 from frame_transforms import operator_positions_km_to_teme
 from scipy.optimize import least_squares
+from sgp4 import omm
 from sgp4.api import WGS84, Satrec
 from sgp4.exporter import export_tle
 from skyfield.api import EarthSatellite, load
@@ -19,7 +20,7 @@ from api.domain.models.interpolable_ephemeris import (
 # When picking a seed TLE from the catalog, prefer rows whose epoch falls in
 # ``[ephemeris_start, ephemeris_start + this many hours]`` (used by
 # ``get_closest_tle``). Falls back to the globally closest TLE otherwise.
-TLE_SEED_PREFERENCE_WINDOW_HOURS = 8.0
+ORBITAL_DATA_SEED_PREFERENCE_WINDOW_HOURS = 8.0
 
 # Penalty magnitude returned by ``residuals`` when SGP4 propagation fails or
 # produces non-finite outputs. Large enough that least_squares (LM) will treat
@@ -31,10 +32,16 @@ LARGE_RESIDUAL = 1.0e6
 # uses to fit a TLE. Must be ``<= EPHEMERIS_DB_SPAN_HOURS``; chosen empirically
 # (20 h gave the lowest XYZ RMS over the 26 h DB span without overfitting the
 # first few hours), but this can be changed later if needed.
-TLE_FIT_WINDOW_HOURS = 20.0
+ORBITAL_DATA_FIT_WINDOW_HOURS = 20.0
 
 # ``sgp4init`` epoch argument: days since 1949-12-31 00:00 UT (JD 2433281.5).
 SGP4_EPOCH_REFERENCE_JD = 2433281.5
+
+# OMM MEAN_MOTION_DOT / MEAN_MOTION_DDOT <-> satrec.ndot / satrec.nddot unit
+# conversions, mirroring ``sgp4.omm._ndot_units`` / ``_nddot_units`` (see
+# SGP4.cpp for the underlying derivation).
+OMM_NDOT_UNITS = 1036800.0 / np.pi
+OMM_NDDOT_UNITS = 2985984000.0 / 2.0 / np.pi
 
 
 def get_closest_tle(
@@ -44,9 +51,10 @@ def get_closest_tle(
     Retrieve a catalog TLE to seed fitting, aligned with ephemeris start time.
 
     Rows whose ``epoch`` falls in
-    ``[ephemeris_start_time, ephemeris_start_time + TLE_SEED_PREFERENCE_WINDOW_HOURS]``
+    ``[ephemeris_start_time, ephemeris_start_time +
+    ORBITAL_DATA_SEED_PREFERENCE_WINDOW_HOURS]``
     are sorted first. Within each group, the row with ``epoch`` closest to
-    ``ephemeris_start_time + TLE_SEED_PREFERENCE_WINDOW_HOURS`` (absolute time
+    ``ephemeris_start_time + ORBITAL_DATA_SEED_PREFERENCE_WINDOW_HOURS`` (absolute time
     difference) wins. If the window is empty, this falls back to the globally
     closest ``epoch`` to that same target — same idea as
     ``TleRepository._get_closest_by_satellite_number``, but with ``sat_id`` and
@@ -62,7 +70,7 @@ def get_closest_tle(
     """
 
     target_time = ephemeris_start_time + timedelta(
-        hours=TLE_SEED_PREFERENCE_WINDOW_HOURS
+        hours=ORBITAL_DATA_SEED_PREFERENCE_WINDOW_HOURS
     )
 
     cursor.execute(
@@ -86,6 +94,91 @@ def get_closest_tle(
     return tle_line1, tle_line2
 
 
+def get_closest_orbital_elements(
+    ephemeris_start_time: datetime, sat_id: int, cursor
+) -> dict | None:
+    """
+    Retrieve catalog OMM elements to seed fitting, aligned with ephemeris start time.
+
+    Same seed-window preference as ``get_closest_tle``, against the
+    ``orbital_elements`` table instead of ``tle``, joined with ``satellites``
+    for ``object_id``/``sat_number`` (not stored on ``orbital_elements`` itself
+    but required by ``sgp4.omm.initialize``).
+
+    Args:
+        ephemeris_start_time (datetime): Ephemeris segment start.
+        sat_id (int): Satellite primary key
+        cursor: Database cursor used to execute SQL.
+
+    Returns:
+        A CCSDS OMM field dict suitable for ``sgp4.omm.initialize``, or
+        ``None`` if no row matches ``sat_id``.
+    """
+
+    target_time = ephemeris_start_time + timedelta(
+        hours=ORBITAL_DATA_SEED_PREFERENCE_WINDOW_HOURS
+    )
+
+    cursor.execute(
+        "SELECT oe.epoch, oe.mean_motion, oe.eccentricity, oe.inclination, "
+        "oe.ra_of_ascending_node, oe.arg_of_pericenter, oe.mean_anomaly, "
+        "oe.ephemeris_type, oe.classification_type, oe.element_set_no, "
+        "oe.rev_at_epoch, oe.bstar, oe.mean_motion_dot, oe.mean_motion_ddot, "
+        "s.object_id, s.sat_number "
+        "FROM orbital_elements oe JOIN satellites s ON s.id = oe.sat_id "
+        "WHERE oe.sat_id = %s "
+        "ORDER BY CASE "
+        "WHEN oe.epoch >= %s::timestamptz "
+        "AND oe.epoch <= %s::timestamptz THEN 0 ELSE 1 END, "
+        "ABS(EXTRACT(EPOCH FROM oe.epoch) - "
+        "EXTRACT(EPOCH FROM %s::timestamptz)) "
+        "LIMIT 1",
+        (sat_id, ephemeris_start_time, target_time, target_time),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        logging.info("Orbital elements not found: %s", ephemeris_start_time)
+        return None
+
+    (
+        epoch,
+        mean_motion,
+        eccentricity,
+        inclination,
+        ra_of_ascending_node,
+        arg_of_pericenter,
+        mean_anomaly,
+        ephemeris_type,
+        classification_type,
+        element_set_no,
+        rev_at_epoch,
+        bstar,
+        mean_motion_dot,
+        mean_motion_ddot,
+        object_id,
+        sat_number,
+    ) = row
+
+    return {
+        "OBJECT_ID": object_id or "",
+        "EPOCH": epoch.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+        "MEAN_MOTION": mean_motion,
+        "ECCENTRICITY": eccentricity,
+        "INCLINATION": inclination,
+        "RA_OF_ASC_NODE": ra_of_ascending_node,
+        "ARG_OF_PERICENTER": arg_of_pericenter,
+        "MEAN_ANOMALY": mean_anomaly,
+        "EPHEMERIS_TYPE": ephemeris_type,
+        "CLASSIFICATION_TYPE": classification_type,
+        "NORAD_CAT_ID": sat_number,
+        "ELEMENT_SET_NO": element_set_no,
+        "REV_AT_EPOCH": rev_at_epoch,
+        "BSTAR": bstar,
+        "MEAN_MOTION_DOT": mean_motion_dot,
+        "MEAN_MOTION_DDOT": mean_motion_ddot,
+    }
+
+
 def ut1_jd_from_datetime(dt: datetime) -> float:
     """UT1 Julian date for an aware or naive UTC ``datetime``."""
     if dt.tzinfo is None:
@@ -101,12 +194,15 @@ def sgp4_epoch_days_from_ut1_jd(jd_ut1: float) -> float:
 
 
 def fit_window_epoch_datetime(window_start: datetime) -> datetime:
-    """Midpoint of the TLE fit window (``window_start + TLE_FIT_WINDOW_HOURS / 2``)."""
+    """
+    Midpoint of the orbital data fit window
+    (``window_start + ORBITAL_DATA_FIT_WINDOW_HOURS / 2``).
+    """
     if window_start.tzinfo is None:
         window_start = window_start.replace(tzinfo=timezone.utc)
     else:
         window_start = window_start.astimezone(timezone.utc)
-    return window_start + timedelta(hours=TLE_FIT_WINDOW_HOURS / 2.0)
+    return window_start + timedelta(hours=ORBITAL_DATA_FIT_WINDOW_HOURS / 2.0)
 
 
 def fit_epoch_jd_from_fit_jds(jd_fit: np.ndarray) -> float:
@@ -117,26 +213,24 @@ def fit_epoch_jd_from_fit_jds(jd_fit: np.ndarray) -> float:
 
 
 def seed_params_at_epoch(
-    line1: str,
-    line2: str,
+    seed_sat: Satrec,
     fit_epoch_dt: datetime,
 ) -> np.ndarray:
     """
     Physical SGP4 parameters at ``fit_epoch_dt`` for LM initialization.
 
-    Propagates the seed TLE to ``fit_epoch_dt`` and maps osculating elements
+    Propagates ``seed_sat`` to ``fit_epoch_dt`` and maps osculating elements
     (Skyfield) to the ``get_fit_params_from_satrec`` vector order. ``ndot`` and
-    ``bstar`` stay from the seed catalog TLE.
+    ``bstar`` stay from ``seed_sat`` as-is (SGP4 does not evolve them).
     """
     if fit_epoch_dt.tzinfo is None:
         fit_epoch_dt = fit_epoch_dt.replace(tzinfo=timezone.utc)
     else:
         fit_epoch_dt = fit_epoch_dt.astimezone(timezone.utc)
 
-    seed_sat = Satrec.twoline2rv(line1, line2)
     ts = load.timescale()
     elements = osculating_elements_of(
-        EarthSatellite(line1, line2, "SAT", ts).at(ts.from_datetime(fit_epoch_dt))
+        EarthSatellite.from_satrec(seed_sat, ts).at(ts.from_datetime(fit_epoch_dt))
     )
     no_kozai = elements.mean_motion_per_day.radians / (24.0 * 60.0)
     return np.array(
@@ -527,41 +621,41 @@ def residuals(
     return ((pos_model_km - pos_obs_km) / km_scale).ravel()
 
 
-def create_tle_from_ephemeris(
+def fit_satrec_to_ephemeris(
     ephemeris: InterpolableEphemeris,
-    cursor,
-    connection,
-) -> tuple[float, float]:
+    seed_sat: Satrec,
+) -> tuple[Satrec | None, float, float]:
     """
-    Fit a TLE to ephemeris position samples using nonlinear least squares.
+    Fit ``seed_sat`` to ephemeris position samples using nonlinear least squares.
 
-    Only the first ``TLE_FIT_WINDOW_HOURS`` of ``ephemeris.points`` are used
+    Only the first ``ORBITAL_DATA_FIT_WINDOW_HOURS`` of ``ephemeris.points`` are used
     for the fit. The returned XYZ / angular RMS are computed against **that
     same subset** -- they are in-sample residuals over the fit window, not
     over the full ``EPHEMERIS_DB_SPAN_HOURS`` retained in the database.
 
-    Before saving, the fitted TLE is also propagated across **every stored
-    ephemeris point** (the full ``EPHEMERIS_DB_SPAN_HOURS``). If SGP4 fails
-    anywhere in that span the TLE is rejected -- the propagation exception
-    propagates and ``save_tle_to_db`` is never called. When propagation
+    The fitted ``Satrec`` is also propagated across **every stored ephemeris
+    point** (the full ``EPHEMERIS_DB_SPAN_HOURS``). If SGP4 fails anywhere in
+    that span the propagation exception propagates. When propagation
     succeeds, fit-window, full-ephemeris, and out-of-window RMS values are
     logged together in a single ``INFO`` message (not used for validation yet.)
 
     Args:
         ephemeris (InterpolableEphemeris): Ephemeris object with timestamped
             position vectors used as fit targets.
+        seed_sat (Satrec): SGP4 satellite record used as the optimization seed.
 
     Returns:
-        tuple[float, float]: XYZ RMS (km) and angular RMS (arcsec) of the
-            fitted TLE versus the ephemeris samples **inside the fit window**.
+        tuple[Satrec | None, float, float]: The fitted ``Satrec`` and its XYZ
+            RMS (km) / angular RMS (arcsec) versus the ephemeris samples
+            **inside the fit window**, or ``(None, -1, -1)`` if the
+            least-squares fit did not converge.
 
     Raises:
         ValueError: If ephemeris has fewer than two points (overall or in the
-            fit window), if no seed TLE exists in the database, or if the
-            least-squares fit does not converge.
-        RuntimeError: If SGP4 fails to propagate the fitted TLE at any
+            fit window).
+        RuntimeError: If SGP4 fails to propagate the fitted ``Satrec`` at any
             stored ephemeris epoch after the optimizer converged (whether
-            inside or outside the fit window). The TLE is not saved.
+            inside or outside the fit window).
     """
     if len(ephemeris.points) < 2:
         raise ValueError("At least two ephemeris points are required to fit a TLE")
@@ -570,18 +664,7 @@ def create_tle_from_ephemeris(
     km_scale = 10.0
     max_nfev = 600
 
-    # Query a nearby catalog TLE to seed the optimizer.
-    seed_lines = get_closest_tle(ephemeris.ephemeris_start, ephemeris.sat_id, cursor)
-    if seed_lines is None:
-        raise ValueError(
-            f"No catalog TLE found for sat_id={ephemeris.sat_id} "
-            f"near ephemeris_start={ephemeris.ephemeris_start}"
-        )
-    line1, line2 = seed_lines
-
-    seed_sat = Satrec.twoline2rv(line1, line2)
-
-    # Limit the fit to the first ``TLE_FIT_WINDOW_HOURS`` of the ephemeris.
+    # Limit the fit to the first ``ORBITAL_DATA_FIT_WINDOW_HOURS`` of the ephemeris.
     # The DB stores up to ``EPHEMERIS_DB_SPAN_HOURS``; the fit window is a
     # strict subset chosen for accuracy over the full stored span.
     timestamped = [
@@ -598,13 +681,13 @@ def create_tle_from_ephemeris(
     timestamped.sort(key=lambda kv: kv[0])
     sorted_points = [p for _, p in timestamped]
     window_start = timestamped[0][0]
-    window_end = window_start + timedelta(hours=TLE_FIT_WINDOW_HOURS)
+    window_end = window_start + timedelta(hours=ORBITAL_DATA_FIT_WINDOW_HOURS)
     fit_window_points = [p for ts, p in timestamped if ts <= window_end]
 
     if len(fit_window_points) < 2:
         raise ValueError(
             f"Only {len(fit_window_points)} ephemeris point(s) in the first "
-            f"{TLE_FIT_WINDOW_HOURS:g} h window; need at least 2 to fit a TLE"
+            f"{ORBITAL_DATA_FIT_WINDOW_HOURS:g} h window; need at least 2 to fit a TLE"
         )
 
     logging.info(
@@ -613,7 +696,7 @@ def create_tle_from_ephemeris(
         len(sorted_points),
         window_start.isoformat(),
         fit_window_points[-1].timestamp.isoformat(),
-        TLE_FIT_WINDOW_HOURS,
+        ORBITAL_DATA_FIT_WINDOW_HOURS,
     )
 
     # Convert point timestamps to UT1 Julian dates for SGP4 calls. Build two
@@ -656,7 +739,7 @@ def create_tle_from_ephemeris(
 
     fit_epoch_dt = fit_window_epoch_datetime(window_start)
     fit_epoch_jd = ut1_jd_from_datetime(fit_epoch_dt)
-    x0 = seed_params_at_epoch(line1, line2, fit_epoch_dt)
+    x0 = seed_params_at_epoch(seed_sat, fit_epoch_dt)
     logging.info(
         "TLE fit epoch at fit-window midpoint: %s (UT1 JD %.8f)",
         fit_epoch_dt.isoformat(),
@@ -699,11 +782,11 @@ def create_tle_from_ephemeris(
 
     if not result.success:
         logging.info(
-            "least_squares did not converge: %s (nfev=%s); TLE not saved",
+            "least_squares did not converge: %s (nfev=%s); not saved",
             result.message,
             result.nfev,
         )
-        return -1, -1
+        return None, -1, -1
         # raise ValueError(f"Least-squares TLE fit did not converge: {result.message}")
 
     fitted_params = unconstrained_to_physical(result.x)
@@ -746,8 +829,105 @@ def create_tle_from_ephemeris(
         result.nfev,
     )
 
+    return fitted, fit_xyz_rms, fit_ang_rms
+
+
+def create_tle_from_ephemeris(
+    ephemeris: InterpolableEphemeris,
+    cursor,
+    connection,
+) -> tuple[float, float]:
+    """
+    Fit a TLE to ephemeris position samples and save it via ``save_tle_to_db``.
+
+    Seeds the fit from the closest catalog TLE (``get_closest_tle``); see
+    ``fit_satrec_to_ephemeris`` for the fit itself.
+
+    Args:
+        ephemeris (InterpolableEphemeris): Ephemeris object with timestamped
+            position vectors used as fit targets.
+
+    Returns:
+        tuple[float, float]: XYZ RMS (km) and angular RMS (arcsec) of the
+            fitted TLE versus the ephemeris samples **inside the fit window**.
+
+    Raises:
+        ValueError: If no seed TLE exists in the database, or (via
+            ``fit_satrec_to_ephemeris``) if ephemeris has fewer than two
+            points.
+        RuntimeError: If SGP4 fails to propagate the fitted TLE at any
+            stored ephemeris epoch after the optimizer converged. The TLE is
+            not saved.
+    """
+    # Query a nearby catalog TLE to seed the optimizer.
+    seed_lines = get_closest_tle(ephemeris.ephemeris_start, ephemeris.sat_id, cursor)
+    if seed_lines is None:
+        raise ValueError(
+            f"No catalog TLE found for sat_id={ephemeris.sat_id} "
+            f"near ephemeris_start={ephemeris.ephemeris_start}"
+        )
+    seed_sat = Satrec.twoline2rv(*seed_lines)
+
+    fitted, fit_xyz_rms, fit_ang_rms = fit_satrec_to_ephemeris(ephemeris, seed_sat)
+    if fitted is None:
+        return fit_xyz_rms, fit_ang_rms
+
     date_collected = datetime.now(timezone.utc)
     save_tle_to_db(fitted, date_collected, ephemeris.sat_id, cursor, connection)
+
+    return fit_xyz_rms, fit_ang_rms
+
+
+def create_orbital_elements_from_ephemeris(
+    ephemeris: InterpolableEphemeris,
+    cursor,
+    connection,
+) -> tuple[float, float]:
+    """
+    Fit OMM elements to ephemeris position samples and save via
+    ``save_orbital_elements_to_db``.
+
+    Seeds the fit from the closest catalog OMM record
+    (``get_closest_orbital_elements``); see ``fit_satrec_to_ephemeris`` for
+    the fit itself.
+
+    Args:
+        ephemeris (InterpolableEphemeris): Ephemeris object with timestamped
+            position vectors used as fit targets.
+
+    Returns:
+        tuple[float, float]: XYZ RMS (km) and angular RMS (arcsec) of the
+            fitted elements versus the ephemeris samples **inside the fit
+            window**.
+
+    Raises:
+        ValueError: If no seed OMM record exists in the database, or (via
+            ``fit_satrec_to_ephemeris``) if ephemeris has fewer than two
+            points.
+        RuntimeError: If SGP4 fails to propagate the fitted elements at any
+            stored ephemeris epoch after the optimizer converged. The record
+            is not saved.
+    """
+    # Query nearby catalog OMM elements to seed the optimizer.
+    seed_fields = get_closest_orbital_elements(
+        ephemeris.ephemeris_start, ephemeris.sat_id, cursor
+    )
+    if seed_fields is None:
+        raise ValueError(
+            f"No catalog orbital elements found for sat_id={ephemeris.sat_id} "
+            f"near ephemeris_start={ephemeris.ephemeris_start}"
+        )
+    seed_sat = Satrec()
+    omm.initialize(seed_sat, seed_fields)
+
+    fitted, fit_xyz_rms, fit_ang_rms = fit_satrec_to_ephemeris(ephemeris, seed_sat)
+    if fitted is None:
+        return fit_xyz_rms, fit_ang_rms
+
+    date_collected = datetime.now(timezone.utc)
+    save_orbital_elements_to_db(
+        fitted, date_collected, ephemeris.sat_id, cursor, connection
+    )
 
     return fit_xyz_rms, fit_ang_rms
 
@@ -813,6 +993,80 @@ def save_tle_to_db(
     if cursor.rowcount == 0:
         logging.warning(
             "TLE not inserted (ON CONFLICT): sat_id=%s epoch=%s data_source=%s",
+            sat_id,
+            epoch,
+            data_source,
+        )
+    connection.commit()
+
+
+def save_orbital_elements_to_db(
+    satrec: Satrec,
+    date_collected: datetime,
+    sat_id: int,
+    cursor,
+    connection,
+) -> None:
+    """
+    Convert ``satrec`` to OMM mean elements and insert into ``orbital_elements``.
+
+    Field conversions are the inverse of ``sgp4.omm.initialize``; ``data_source``
+    is fixed to ``"generated"``, matching ``save_tle_to_db``. Inserts use
+    ``ON CONFLICT (SAT_ID, EPOCH, DATA_SOURCE) DO NOTHING`` so duplicate runs
+    are idempotent; a conflict logs a warning but does not raise.
+
+    Args:
+        satrec (Satrec): Fitted SGP4 satellite record to convert.
+        date_collected (datetime): When this record was produced (UTC).
+        sat_id (int): Satellites table primary key the record belongs to.
+        cursor: Database cursor used to execute SQL.
+        connection: Database connection; ``commit()`` is called on success.
+    """
+    epoch = Time(
+        satrec.jdsatepoch + satrec.jdsatepochF,
+        format="jd",
+        scale="utc",
+    ).to_datetime(timezone.utc)
+
+    data_source = "generated"
+    mean_motion = satrec.no_kozai * 720.0 / np.pi
+    mean_motion_dot = satrec.ndot * OMM_NDOT_UNITS
+    mean_motion_ddot = satrec.nddot * OMM_NDDOT_UNITS
+
+    orbital_elements_insert_query = """
+        INSERT INTO orbital_elements (SAT_ID, DATE_COLLECTED, EPOCH, DATA_SOURCE,
+        MEAN_MOTION, ECCENTRICITY, INCLINATION, RA_OF_ASCENDING_NODE, ARG_OF_PERICENTER,
+        MEAN_ANOMALY, EPHEMERIS_TYPE, CLASSIFICATION_TYPE, ELEMENT_SET_NO, REV_AT_EPOCH,
+        BSTAR, MEAN_MOTION_DOT, MEAN_MOTION_DDOT)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (SAT_ID, EPOCH, DATA_SOURCE) DO NOTHING"""
+
+    cursor.execute(
+        orbital_elements_insert_query,
+        (
+            sat_id,
+            date_collected,
+            epoch,
+            data_source,
+            mean_motion,
+            satrec.ecco,
+            np.degrees(satrec.inclo),
+            np.degrees(satrec.nodeo),
+            np.degrees(satrec.argpo),
+            np.degrees(satrec.mo),
+            satrec.ephtype,
+            satrec.classification,
+            satrec.elnum,
+            satrec.revnum,
+            satrec.bstar,
+            mean_motion_dot,
+            mean_motion_ddot,
+        ),
+    )
+    if cursor.rowcount == 0:
+        logging.warning(
+            "Orbital elements not inserted (ON CONFLICT): "
+            "sat_id=%s epoch=%s data_source=%s",
             sat_id,
             epoch,
             data_source,

--- a/src/data/orbital_data_generation.py
+++ b/src/data/orbital_data_generation.py
@@ -881,6 +881,7 @@ def create_tle_from_ephemeris(
 
 def create_orbital_elements_from_ephemeris(
     ephemeris: InterpolableEphemeris,
+    satellite_id: int,
     cursor,
     connection,
 ) -> tuple[float, float]:
@@ -911,11 +912,11 @@ def create_orbital_elements_from_ephemeris(
     """
     # Query nearby catalog OMM elements to seed the optimizer.
     seed_fields = get_closest_orbital_elements(
-        ephemeris.ephemeris_start, ephemeris.sat_id, cursor
+        ephemeris.ephemeris_start, satellite_id, cursor
     )
     if seed_fields is None:
         raise ValueError(
-            f"No catalog orbital elements found for sat_id={ephemeris.sat_id} "
+            f"No catalog orbital elements found for sat_id={satellite_id} "
             f"near ephemeris_start={ephemeris.ephemeris_start}"
         )
     seed_sat = Satrec()
@@ -927,7 +928,7 @@ def create_orbital_elements_from_ephemeris(
 
     date_collected = datetime.now(timezone.utc)
     save_orbital_elements_to_db(
-        fitted, date_collected, ephemeris.sat_id, cursor, connection
+        fitted, date_collected, satellite_id, cursor, connection
     )
 
     return fit_xyz_rms, fit_ang_rms

--- a/tests/integration/test_tools_routes.py
+++ b/tests/integration/test_tools_routes.py
@@ -189,7 +189,7 @@ def test_get_adjacent_tles(client, session, services_available):
         f"/tools/get-adjacent-tles/?id=25544&id_type=catalog&epoch={epoch_jd}"
     )
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 2
+    assert len(response.json[0]["orbital_data"]) == 2
 
 
 def test_get_adjacent_tles_nonexistent_satellite(client, session, services_available):
@@ -204,7 +204,7 @@ def test_get_adjacent_tles_nonexistent_satellite(client, session, services_avail
 
     # Should return success but with empty tle_data
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 0
+    assert len(response.json[0]["orbital_data"]) == 0
 
 
 def test_get_adjacent_tles_errors(client, session, services_available):
@@ -261,7 +261,7 @@ def test_get_nearest_tle(client, session, services_available):
         f"/tools/get-nearest-tle/?id=25544&id_type=catalog&epoch={epoch_jd}"
     )
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 1
+    assert len(response.json[0]["orbital_data"]) == 1
 
     # Use a satellite ID that doesn't exist in the database
     response = client.get(
@@ -270,7 +270,7 @@ def test_get_nearest_tle(client, session, services_available):
 
     # Should return success but with empty tle_data
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 0
+    assert len(response.json[0]["orbital_data"]) == 0
 
 
 def test_get_nearest_tle_nonexistent_satellite(client, session, services_available):
@@ -285,7 +285,7 @@ def test_get_nearest_tle_nonexistent_satellite(client, session, services_availab
 
     # Should return success but with empty tle_data
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 0
+    assert len(response.json[0]["orbital_data"]) == 0
 
 
 @pytest.mark.parametrize(
@@ -356,8 +356,8 @@ def test_get_nearest_tle_name_id_type(client, session, services_available):
     )
 
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 1
-    assert response.json[0]["tle_data"][0]["satellite_name"] == "TEST_SAT"
+    assert len(response.json[0]["orbital_data"]) == 1
+    assert response.json[0]["orbital_data"][0]["satellite_name"] == "TEST_SAT"
 
 
 def test_get_tles_around_epoch(client, session, services_available):
@@ -377,7 +377,7 @@ def test_get_tles_around_epoch(client, session, services_available):
         f"/tools/get-tles-around-epoch/?id=25544&id_type=catalog&epoch={epoch_jd}"
     )
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 2
+    assert len(response.json[0]["orbital_data"]) == 2
 
 
 def test_get_tles_around_epoch_nonexistent_satellite(
@@ -394,7 +394,7 @@ def test_get_tles_around_epoch_nonexistent_satellite(
 
     # Should return success but with empty tle_data
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 0
+    assert len(response.json[0]["orbital_data"]) == 0
 
 
 @pytest.mark.parametrize(
@@ -483,21 +483,21 @@ def test_get_tles_around_epoch_custom_counts(client, session, services_available
         f"/tools/get-tles-around-epoch/?id=25544&id_type=catalog&epoch={epoch_jd}"
     )
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 4
+    assert len(response.json[0]["orbital_data"]) == 4
 
     # Test with custom counts (3 before, 1 after)
     response = client.get(
         f"/tools/get-tles-around-epoch/?id=25544&id_type=catalog&epoch={epoch_jd}&count_before=3&count_after=1"
     )
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 4
+    assert len(response.json[0]["orbital_data"]) == 4
 
     # Test with custom counts (0 before, 4 after)
     response = client.get(
         f"/tools/get-tles-around-epoch/?id=25544&id_type=catalog&epoch={epoch_jd}&count_before=0&count_after=4"
     )
     assert response.status_code == 200
-    assert len(response.json[0]["tle_data"]) == 4
+    assert len(response.json[0]["orbital_data"]) == 4
 
     # Test with invalid counts
     response = client.get(

--- a/tests/unit/test_fov_service.py
+++ b/tests/unit/test_fov_service.py
@@ -66,7 +66,7 @@ def test_satellite_in_fov(test_location, test_time):
         dec=75.774139,
         fov_radius=1.66,
         group_by="satellite",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=False,
         constellation=None,
         data_source="any",
@@ -93,7 +93,7 @@ def test_satellite_in_fov(test_location, test_time):
         dec=75.774139,
         fov_radius=1.66,
         group_by="time",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=False,
         constellation=None,
         data_source=None,
@@ -116,9 +116,9 @@ def test_satellite_in_fov(test_location, test_time):
     assert result["data"][0]["ra"] == pytest.approx(21.23511431, rel=1e-9)
     assert result["data"][0]["dec"] is not None
     with pytest.raises(KeyError):
-        assert result["data"][0]["tle_data"]
+        assert result["data"][0]["orbital_data"]
 
-    # Test with group_by=time and include_tles=True
+    # Test with group_by=time and include_orbital_data=True
     result = get_satellite_passes_in_fov(
         tle_repo,
         orbital_elements_repo,
@@ -131,7 +131,7 @@ def test_satellite_in_fov(test_location, test_time):
         dec=75.774139,
         fov_radius=2.0,
         group_by="time",
-        include_tles=True,
+        include_orbital_data=True,
         skip_cache=False,
         constellation=None,
         data_source=None,
@@ -142,10 +142,10 @@ def test_satellite_in_fov(test_location, test_time):
         api_version="1.0",
     )
 
-    assert result["data"][0]["tle_data"]["tle_line1"] == tle.tle_line1
-    assert result["data"][0]["tle_data"]["tle_line2"] == tle.tle_line2
+    assert result["data"][0]["orbital_data"]["tle_line1"] == tle.tle_line1
+    assert result["data"][0]["orbital_data"]["tle_line2"] == tle.tle_line2
 
-    # Test with group_by=satellite and include_tles=True
+    # Test with group_by=satellite and include_orbital_data=True
     result = get_satellite_passes_in_fov(
         tle_repo,
         orbital_elements_repo,
@@ -158,7 +158,7 @@ def test_satellite_in_fov(test_location, test_time):
         dec=75.774139,
         fov_radius=2.5,
         group_by="satellite",
-        include_tles=True,
+        include_orbital_data=True,
         skip_cache=False,
         constellation=None,
         data_source="any",
@@ -171,11 +171,11 @@ def test_satellite_in_fov(test_location, test_time):
     # Get the first satellite key
     satellite_key = list(result["data"]["satellites"].keys())[0]
     assert (
-        result["data"]["satellites"][satellite_key]["tle_data"]["tle_line1"]
+        result["data"]["satellites"][satellite_key]["orbital_data"]["tle_line1"]
         == tle.tle_line1
     )
     assert (
-        result["data"]["satellites"][satellite_key]["tle_data"]["tle_line2"]
+        result["data"]["satellites"][satellite_key]["orbital_data"]["tle_line2"]
         == tle.tle_line2
     )
 
@@ -238,7 +238,7 @@ def test_satellite_in_fov_orbital_elements_after_cutoff(test_location):
         dec=-22.18,
         fov_radius=1.0,
         group_by="satellite",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=True,
         constellation=None,
         data_source="any",
@@ -298,7 +298,7 @@ def test_tle_and_orbital_elements_propagation_match(test_location, test_time):
         dec=75.774139,
         fov_radius=1.66,
         group_by="time",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=True,
         constellation=None,
         data_source="any",
@@ -392,7 +392,7 @@ def test_get_satellite_passes_in_fov_async_orbital_elements_after_cutoff(test_lo
             dec=-22.18,
             fov_radius=1.0,
             group_by="satellite",
-            include_tles=False,
+            include_orbital_data=False,
             skip_cache=True,
             constellation=None,
             data_source="any",
@@ -461,7 +461,7 @@ def test_satellite_outside_fov(test_location, test_time):
         dec=75.774139,
         fov_radius=2.0,
         group_by="satellite",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=False,
         constellation=None,
         data_source="any",
@@ -511,7 +511,7 @@ def test_fov_service_uses_ephemeris(starlink_ephemeris):
         dec=-0.9114941,
         fov_radius=180.0,
         group_by="time",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=True,
         constellation=None,
         data_source=None,
@@ -539,7 +539,7 @@ def test_fov_service_uses_ephemeris(starlink_ephemeris):
         dec=-0.9114941,
         fov_radius=180.0,
         group_by="time",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=True,
         constellation=None,
         data_source=None,
@@ -677,7 +677,7 @@ def test_empty_tle_list(test_location, test_time):
         dec=75.774139,
         fov_radius=2.0,
         group_by="satellite",
-        include_tles=False,
+        include_orbital_data=False,
         skip_cache=False,
         constellation=None,
         data_source=None,
@@ -1104,7 +1104,7 @@ def test_fov_different_cache_keys(mocker, test_location, test_time):
             "dec": -20.0,
             "fov_radius": 10.0,
             "group_by": "time",
-            "include_tles": False,
+            "include_orbital_data": False,
             "skip_cache": False,
             "constellation": None,
             "data_source": None,

--- a/tests/unit/test_tools_service.py
+++ b/tests/unit/test_tools_service.py
@@ -407,12 +407,12 @@ def test_get_adjacent_tles():
     results = get_adjacent_tle_results(
         tle_repo, 25544, "catalog", epoch_jd, "test", "1.0"
     )
-    assert len(results[0]["tle_data"]) == 2
-    assert results[0]["tle_data"][0]["satellite_id"] == 25544
-    assert results[0]["tle_data"][1]["satellite_id"] == 25544
+    assert len(results[0]["orbital_data"]) == 2
+    assert results[0]["orbital_data"][0]["satellite_id"] == 25544
+    assert results[0]["orbital_data"][1]["satellite_id"] == 25544
 
     results = get_adjacent_tle_results(tle_repo, 1, "catalog", epoch_jd, "test", "1.0")
-    assert len(results[0]["tle_data"]) == 0
+    assert len(results[0]["orbital_data"]) == 0
 
 
 def test_get_nearest_tle():
@@ -427,11 +427,11 @@ def test_get_nearest_tle():
     tle_repo = FakeTLERepository([tle_1, tle_2])
 
     results = get_nearest_tle_result(tle_repo, 25544, "catalog", epoch, "test", "1.0")
-    assert results[0]["tle_data"][0]["tle_line1"] == tle_1.tle_line1
-    assert results[0]["tle_data"][0]["tle_line2"] == tle_1.tle_line2
+    assert results[0]["orbital_data"][0]["tle_line1"] == tle_1.tle_line1
+    assert results[0]["orbital_data"][0]["tle_line2"] == tle_1.tle_line2
 
     results = get_nearest_tle_result(tle_repo, 1, "catalog", epoch, "test", "1.0")
-    assert len(results[0]["tle_data"]) == 0
+    assert len(results[0]["orbital_data"]) == 0
 
 
 def test_get_tles_around_epoch():
@@ -451,22 +451,22 @@ def test_get_tles_around_epoch():
     results = get_tles_around_epoch_results(
         tle_repo, 25544, "catalog", epoch, 2, 2, "test", "1.0"
     )
-    assert len(results[0]["tle_data"]) == 3
+    assert len(results[0]["orbital_data"]) == 3
 
     results = get_tles_around_epoch_results(
         tle_repo, 25544, "catalog", epoch, 1, 1, "test", "1.0"
     )
-    assert len(results[0]["tle_data"]) == 2
+    assert len(results[0]["orbital_data"]) == 2
 
     results = get_tles_around_epoch_results(
         tle_repo, 25544, "catalog", epoch, 1, 1, "test", "1.0"
     )
-    assert len(results[0]["tle_data"]) == 2
+    assert len(results[0]["orbital_data"]) == 2
 
     results = get_tles_around_epoch_results(
         tle_repo, 25544, "catalog", epoch, 0, 2, "test", "1.0"
     )
-    assert len(results[0]["tle_data"]) == 2
+    assert len(results[0]["orbital_data"]) == 2
 
 
 def test_get_satellite_data():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -193,7 +193,7 @@ def test_process_satellite_batch():
     elevation = 300
     fov_center = (24.797270, 75.774139)
     fov_radius = 2.0
-    include_tles = True
+    include_orbital_data = True
     illuminated_only = False
 
     args = (
@@ -204,7 +204,7 @@ def test_process_satellite_batch():
         elevation,
         fov_center,
         fov_radius,
-        include_tles,
+        include_orbital_data,
         illuminated_only,
     )
     result = process_satellite_batch(args)
@@ -221,7 +221,7 @@ def test_process_satellite_batch():
         elevation,
         fov_center,
         fov_radius,
-        include_tles,
+        include_orbital_data,
         illuminated_only,
     )
     result = process_satellite_batch(args)


### PR DESCRIPTION
### Description:
The experimental TLEs generated from ephemeris data will now be replaced with the equivalent generated OMM fields. Also references to `tle_data` and `include_tle_data` in API requests/responses will be replaced with `orbital _data` and `include_orbital_data`, although the API doesn't yet return the OMM format used, that is still in progress


