### PR TITLE
Return 400 instead of 500 for invalid dates on search-satellites

### DIFF
--- a/src/api/changes/250.bugfix.md
+++ b/src/api/changes/250.bugfix.md
@@ -1,0 +1,1 @@
+Return HTTP 400 instead of 500 when a `launch_date` or `decay_date` search parameter on the search-satellites endpoint is not a valid Julian Date (for example a calendar date like `2024-01-01`).

--- a/src/api/services/validation_service.py
+++ b/src/api/services/validation_service.py
@@ -585,7 +585,12 @@ def validate_parameters(
                 .replace(tzinfo=timezone.utc)
             )
     except Exception as e:
-        raise ValidationError(500, error_messages.INVALID_JD, e) from e
+        raise ValidationError(
+            400,
+            error_messages.INVALID_JD
+            + " - launch_date and decay_date parameters must be in Julian Date format",
+            e,
+        ) from e
 
     if "norad_id" in parameters.keys() and parameters["norad_id"] is not None:
         parameters["norad_id"] = _parse_norad_id(parameters["norad_id"], "norad_id")

--- a/tests/unit/test_validation_service.py
+++ b/tests/unit/test_validation_service.py
@@ -621,3 +621,21 @@ def test_validate_parameters_norad_id_non_integer(app, path, parameter_list, req
         with pytest.raises(ValidationError, match="must be an integer NORAD ID") as exc:
             validate_parameters(request, parameter_list, required)
         assert exc.value.status_code == 400
+
+
+def test_validate_parameters_search_invalid_date_returns_400(app):
+    # A calendar-style date (not Julian Date) on search-satellites must 400, not 500
+    with app.test_request_context(
+        "/tools/search-satellites/?launch_date_start=2024-01-01"
+    ):
+        with pytest.raises(ValidationError, match="Julian Date") as exc:
+            validate_parameters(request, ["launch_date_start"], [])
+        assert exc.value.status_code == 400
+
+
+def test_validate_parameters_search_valid_jd_date(app):
+    with app.test_request_context(
+        "/tools/search-satellites/?decay_date_start=2451571.517396"
+    ):
+        parameters = validate_parameters(request, ["decay_date_start"], [])
+        assert parameters["decay_date_start"] is not None


### PR DESCRIPTION
The `launch_date_*` / `decay_date_*` search parameters are parsed as Julian Dates. A non-JD value such as a calendar date (`2024-01-01`) is invalid client input but currently raises `ValidationError(500)`, so the endpoint returns a 500.

This raises a 400 with a clearer message (noting the parameters must be Julian Date format) instead, and adds unit tests for the invalid (400) and valid (JD) cases.