### PR TITLE
TDM data upload fix and return 400 for invalid date on search-satellite endpoint

### DIFF
--- a/src/api/changes/250.bugfix.md
+++ b/src/api/changes/250.bugfix.md
@@ -1,0 +1,1 @@
+Return HTTP 400 instead of 500 when a `launch_date` or `decay_date` search parameter on the search-satellites endpoint is not a valid Julian Date (for example a calendar date like `2024-01-01`).

--- a/src/api/services/validation_service.py
+++ b/src/api/services/validation_service.py
@@ -585,7 +585,12 @@ def validate_parameters(
                 .replace(tzinfo=timezone.utc)
             )
     except Exception as e:
-        raise ValidationError(500, error_messages.INVALID_JD, e) from e
+        raise ValidationError(
+            400,
+            error_messages.INVALID_JD
+            + " - launch_date and decay_date parameters must be in Julian Date format",
+            e,
+        ) from e
 
     if "norad_id" in parameters.keys() and parameters["norad_id"] is not None:
         parameters["norad_id"] = _parse_norad_id(parameters["norad_id"], "norad_id")

--- a/src/data/tdm_utils.py
+++ b/src/data/tdm_utils.py
@@ -147,8 +147,10 @@ def parse_tdm_file(file_content: bytes) -> list[dict]:
         - first_timestamp: First timestamp in this block
         - last_timestamp: Last timestamp in this block
 
-    Raises:
-        ValueError: If required fields are missing
+    Note:
+        Returns an empty list for a file with no data blocks (e.g. a
+        header-only stub) rather than raising, so callers can skip it without
+        aborting the surrounding batch.
     """
     text_content = file_content.decode("utf-8")
     lines = text_content.splitlines()
@@ -240,7 +242,10 @@ def parse_tdm_file(file_content: bytes) -> list[dict]:
             i += 1
 
     if not blocks:
-        raise ValueError("No valid data blocks found in TDM file")
+        # Header-only / blockless exports carry no data to ingest. Return empty
+        # so the caller skips the file instead of aborting the whole batch.
+        logger.warning("No data blocks found in TDM file; treating as empty")
+        return []
 
     logger.info(f"Parsed {len(blocks)} data block(s) from TDM file")
     return blocks
@@ -291,7 +296,11 @@ def process_zip_file(
                     parsed_blocks = parse_tdm_file(file_content)
                     # parsed_blocks is a list of blocks of position data,
                     # each with its own metadata, since a file can contain multiple
-                    # blocks like these
+                    # blocks like these. An empty list means a header-only/blockless
+                    # file (nothing to ingest); skip it and keep processing.
+                    if not parsed_blocks:
+                        logger.warning(f"    Skipping empty TDM {file_name}")
+                        continue
 
                     point_rows: list[tuple[int, str, float, float, float | None]] = []
                     date_added = datetime.now(timezone.utc)

--- a/tests/unit/test_validation_service.py
+++ b/tests/unit/test_validation_service.py
@@ -621,3 +621,21 @@ def test_validate_parameters_norad_id_non_integer(app, path, parameter_list, req
         with pytest.raises(ValidationError, match="must be an integer NORAD ID") as exc:
             validate_parameters(request, parameter_list, required)
         assert exc.value.status_code == 400
+
+
+def test_validate_parameters_search_invalid_date_returns_400(app):
+    # A calendar-style date (not Julian Date) on search-satellites must 400, not 500
+    with app.test_request_context(
+        "/tools/search-satellites/?launch_date_start=2024-01-01"
+    ):
+        with pytest.raises(ValidationError, match="Julian Date") as exc:
+            validate_parameters(request, ["launch_date_start"], [])
+        assert exc.value.status_code == 400
+
+
+def test_validate_parameters_search_valid_jd_date(app):
+    with app.test_request_context(
+        "/tools/search-satellites/?decay_date_start=2451571.517396"
+    ):
+        parameters = validate_parameters(request, ["decay_date_start"], [])
+        assert parameters["decay_date_start"] is not None


### PR DESCRIPTION
### Description:
- TDM files with empty data blocks no longer block the entire TDM upload
- search-satellites endpoint now returns 400 instead of 500 for invalid date format for launch and decay dates



- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
- [x] Changelog fragment added under `src/api/changes/` (for code changes)
