### PR TITLE
Fix for temp Celestrak ids not getting updated to correct NORAD ids, and fix missing Starlink generations

### DIFF
--- a/src/api/adapters/database_orm.py
+++ b/src/api/adapters/database_orm.py
@@ -59,6 +59,7 @@ class SatelliteDb(Base):
         ),
         Index("idx_satellites_has_current_sat_number", has_current_sat_number),
         Index("idx_satellites_sat_number_sat_name", sat_number, sat_name),
+        Index("idx_satellites_object_id", object_id),
     )
 
 

--- a/src/api/migrations/versions/b7e3c1ad4f2a_add_unique_tdm_folder_track.py
+++ b/src/api/migrations/versions/b7e3c1ad4f2a_add_unique_tdm_folder_track.py
@@ -1,0 +1,33 @@
+"""Add unique constraint on tdm_predictions (folder_name, track_id)
+
+Prevents duplicate ingest of the same track from the same zip delivery.
+
+Revision ID: b7e3c1ad4f2a
+Revises: c41e8a9d02f7
+Create Date: 2026-07-22 11:05:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7e3c1ad4f2a"
+down_revision = "c41e8a9d02f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(
+        "tdm_predictions_folder_name_track_id_key",
+        "tdm_predictions",
+        ["folder_name", "track_id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "tdm_predictions_folder_name_track_id_key",
+        "tdm_predictions",
+        type_="unique",
+    )

--- a/src/api/migrations/versions/c41e8a9d02f7_add_is_canonical_to_generated_orbital_data.py
+++ b/src/api/migrations/versions/c41e8a9d02f7_add_is_canonical_to_generated_orbital_data.py
@@ -1,0 +1,48 @@
+"""add is_canonical to tle and orbital_elements
+
+Multi-set generation fits several short-window element sets per ephemeris
+file for serving accuracy, plus one regular full-window set kept for
+archival. ``is_canonical`` marks the archival set: retention
+(``delete_expired_generated_orbital_data``) prunes only generated rows where
+it is false. Catalog rows keep the default false; the flag is only
+meaningful for ``data_source = 'generated'``.
+
+Revision ID: c41e8a9d02f7
+Revises: 371f0dee9465
+Create Date: 2026-07-17 09:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c41e8a9d02f7"
+down_revision = "371f0dee9465"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for table in ("tle", "orbital_elements"):
+        op.add_column(
+            table,
+            sa.Column(
+                "is_canonical",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+    # Pre-existing generated rows are single regular fits (one per ephemeris
+    # file), i.e. exactly the archival sets this flag preserves.
+    op.execute("UPDATE tle SET is_canonical = true WHERE data_source = 'generated'")
+    op.execute(
+        "UPDATE orbital_elements SET is_canonical = true "
+        "WHERE data_source = 'generated'"
+    )
+
+
+def downgrade():
+    for table in ("tle", "orbital_elements"):
+        op.drop_column(table, "is_canonical")

--- a/src/api/migrations/versions/e4b9f1c72a30_add_object_id_index_to_satellites.py
+++ b/src/api/migrations/versions/e4b9f1c72a30_add_object_id_index_to_satellites.py
@@ -1,0 +1,34 @@
+"""add object_id index to satellites
+
+Ingestion demotes temporary-id rows in favor of the real catalog id for the
+same object, keyed on ``object_id`` (see src/data/tle_utils.py). That lookup
+runs on every ingested record, so ``satellites.object_id`` needs an index.
+Built CONCURRENTLY to avoid locking the live table during ingestion.
+
+Revision ID: e4b9f1c72a30
+Revises: b7e3c1ad4f2a
+Create Date: 2026-09-01 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e4b9f1c72a30"
+down_revision = "b7e3c1ad4f2a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # CONCURRENTLY cannot run inside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_satellites_object_id "
+            "ON satellites (object_id)"
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_satellites_object_id")

--- a/src/data/satellite_utils.py
+++ b/src/data/satellite_utils.py
@@ -72,9 +72,12 @@ def get_starlink_satellites(cursor: psycopg2.extensions.cursor) -> list[tuple]:
         cursor: Database cursor
 
     Returns:
-        List of satellite tuples
+        List of satellite tuples: (id, sat_number, sat_name, object_id).
     """
-    cursor.execute("SELECT * FROM satellites WHERE sat_name LIKE '%STARLINK%'")
+    cursor.execute(
+        "SELECT id, sat_number, sat_name, object_id "
+        "FROM satellites WHERE sat_name LIKE '%STARLINK%'"
+    )
     return cursor.fetchall()
 
 
@@ -295,10 +298,11 @@ def get_starlink_generations(cursor, connection):
     """
     current_starlink_satellites = get_starlink_satellites(cursor)
 
-    # Prepare satellite data for matching
+    # Prepare satellite data for matching. Columns come from the explicit SELECT
+    # in get_starlink_satellites: (id, sat_number, sat_name, object_id).
     sat_id_number_and_launch = []
     for satellite in current_starlink_satellites:
-        launch_number = extract_launch_number(satellite[10])
+        launch_number = extract_launch_number(satellite[3])
         sat_id_number_and_launch.append(
             (satellite[0], satellite[1], satellite[2], launch_number)
         )
@@ -322,3 +326,9 @@ def get_starlink_generations(cursor, connection):
     logging.info(
         f"Updated generation information for {total_matched} Starlink satellites"
     )
+    unmatched = len(current_starlink_satellites) - total_matched
+    if unmatched > 0:
+        logging.warning(
+            f"{unmatched} of {len(current_starlink_satellites)} Starlink satellites "
+            "were not matched to a generation"
+        )

--- a/src/data/tle_utils.py
+++ b/src/data/tle_utils.py
@@ -8,6 +8,12 @@ from connections import get_spacetrack_login
 from psycopg2.extras import execute_values
 from skyfield.api import EarthSatellite, load
 
+# Highest catalog number a real NORAD id can hold (alpha-5 ceiling: "Z9999").
+# Celestrak publishes freshly launched objects under temporary placeholder ids
+# above this range until they are officially cataloged; those are not real ids
+# and must not remain the current designation once the real id arrives.
+MAX_VALID_NORAD = 339999
+
 
 def _parse_omm_float(value):
     if value is None:
@@ -130,6 +136,22 @@ def insert_record(
         sat_number = int(sat_number)
 
     current_date_time = datetime.datetime.now(datetime.timezone.utc)
+
+    # A temporary-id row must never claim the current designation when the real
+    # (valid) id already owns this object. This handles the out-of-order case
+    # where the real id is seen before this object's temp id is first inserted;
+    # the normal temp-then-real order is handled by the demotion below.
+    effective_current = is_current_number
+    if effective_current and object_id and sat_number > MAX_VALID_NORAD:
+        cursor.execute(
+            "SELECT 1 FROM satellites "
+            "WHERE object_id = %s AND sat_number <= %s AND has_current_sat_number "
+            "LIMIT 1",
+            (object_id, MAX_VALID_NORAD),
+        )
+        if cursor.fetchone() is not None:
+            effective_current = False
+
     # add satellite to database if it doesn't already exist
     sat_to_insert = (
         sat_number,
@@ -142,7 +164,7 @@ def insert_record(
         decay_date,
         object_id,
         object_type,
-        is_current_number,
+        effective_current,
         str(sat_number),
         name,
     )
@@ -194,6 +216,25 @@ def insert_record(
 
     params = (current_date_time, sat_number, sat_id)
     cursor.execute(update_query, params)
+
+    # A satellite first appears under a Celestrak temporary NORAD id and is later
+    # reissued under its real catalog number. Same idea as a real name replacing
+    # "TBA - TO BE ASSIGNED", but the id changes, so the demotion above (keyed on
+    # sat_number) misses it. When a valid id is ingested for this object, demote
+    # any temporary-id row(s) for the same object so the real id becomes primary.
+    if object_id and sat_number <= MAX_VALID_NORAD:
+        demote_temp_query = """
+            UPDATE satellites
+            SET HAS_CURRENT_SAT_NUMBER = FALSE,
+                DATE_MODIFIED = %s
+            WHERE OBJECT_ID = %s
+            AND SAT_NUMBER > %s
+            AND id != %s
+            """
+        cursor.execute(
+            demote_temp_query,
+            (current_date_time, object_id, MAX_VALID_NORAD, sat_id),
+        )
 
     # make sure this satellite has the correct has_current_sat_number value
     # only allow data from space-track to update this value, celestrak has
@@ -531,6 +572,18 @@ def add_archival_spacetrack_tles_to_db(
         WHERE id = %s
         """
 
+            # Demote temporary-id rows for the same object when a valid id is
+            # ingested (see insert_record for the rationale). Keyed on object_id
+            # because the id itself changes across the temp -> real transition.
+            demote_temp_query = """
+        UPDATE satellites
+        SET HAS_CURRENT_SAT_NUMBER = FALSE,
+            DATE_MODIFIED = %s
+        WHERE OBJECT_ID = %s
+        AND SAT_NUMBER > %s
+        AND id != %s
+        """
+
             step = "update has_current_sat_number"
             if new_sat_keys:
                 log_time = datetime.datetime.now(datetime.UTC).strftime(
@@ -547,6 +600,19 @@ def add_archival_spacetrack_tles_to_db(
                     false_params.append((current_date_time, sat_key[0], sat_id))
 
                 cursor.executemany(update_false_query, false_params)
+
+                demote_temp_params = [
+                    (
+                        current_date_time,
+                        sats_to_insert[sat_key][8],  # object_id
+                        MAX_VALID_NORAD,
+                        sat_id_by_key[sat_key],
+                    )
+                    for sat_key in new_sat_keys
+                    if sats_to_insert[sat_key][8] and sat_key[0] <= MAX_VALID_NORAD
+                ]
+                if demote_temp_params:
+                    cursor.executemany(demote_temp_query, demote_temp_params)
 
                 # make sure this satellite has the correct has_current_sat_number value
                 # only allow data from space-track to update this value, celestrak has


### PR DESCRIPTION
### Description:
Celestrak uses temporary ids instead of temporary names (like TBA), but when the actual NORAD id came through in SpaceTrack, there was no connection to the original object in order to be able to change `has_current_sat_number` to false the first one and add the new entry. 

The Starlink generation info wasn't getting saved correctly either, since the object id as retrieved from the satellite row in the database wasn't in the expected index. Changed the query to get only the satellite properties specifically needed so the index is guaranteed.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
- [x] Changelog fragment added under `src/api/changes/` (for code changes)
